### PR TITLE
New framework with arbitrary spin and parity produced! 

### DIFF
--- a/executables/XYZ_plots/X3872_high.cpp
+++ b/executables/XYZ_plots/X3872_high.cpp
@@ -38,10 +38,12 @@ int main( int argc, char** argv )
     // Chi_c1(1P)
     double mChi = 3.510;
     reaction_kinematics * kChi = new reaction_kinematics(mChi);
+    kChi->set_JP(1, 1);
 
     // X(3872)
     double mX = 3.87169;
     reaction_kinematics * kX = new reaction_kinematics(mX);
+    kX->set_JP(1, 1);
 
     // Nucleon couplings 
     double gV_omega = 16., gT_omega = 0.;

--- a/executables/XYZ_plots/X3872_high.cpp
+++ b/executables/XYZ_plots/X3872_high.cpp
@@ -47,10 +47,10 @@ int main( int argc, char** argv )
 
     // Nucleon couplings 
     double gV_omega = 16., gT_omega = 0.;
-    double bOmega = 0.68; // Cuttoff of LamOmega = 1.2 GeV
+    double LamOmega = 1.2;
 
     double gV_rho = 2.4, gT_rho = 14.6;
-    double bRho = 0.51; // Cuttoff of LamRho = 1.4 GeV
+    double LamRho = 1.4;
 
     double gV_phi = -6.2, gT_phi = 2.1;
 
@@ -68,12 +68,12 @@ int main( int argc, char** argv )
     double gChi_omega = 5.2E-4;
     vector_exchange Chi_omega(kChi, alpha, "#omega");
     Chi_omega.set_params({gChi_omega, gV_omega, gT_omega});
-    Chi_omega.set_formfactor(true, bOmega);
+    Chi_omega.set_formfactor(true, LamOmega);
 
     double gChi_rho = 9.2E-4;
     vector_exchange Chi_rho(kChi, alpha, "#rho");
     Chi_rho.set_params({gChi_rho, gV_rho, gT_rho});
-    Chi_rho.set_formfactor(true, bRho);
+    Chi_rho.set_formfactor(true, LamRho);
 
     std::vector<amplitude*> chi_exchanges = {&Chi_omega, &Chi_rho};
     amplitude_sum chi(kChi, chi_exchanges, "#it{#chi_{c1}(1P)}");
@@ -84,12 +84,12 @@ int main( int argc, char** argv )
     double gX_omega = 8.2E-3;
     vector_exchange X_omega(kX, alpha, "#omega");
     X_omega.set_params({gX_omega, gV_omega, gT_omega});
-    X_omega.set_formfactor(true, bOmega);
+    X_omega.set_formfactor(true, LamOmega);
 
     double gX_rho = 3.6E-3;
     vector_exchange X_rho(kX, alpha, "#rho");
     X_rho.set_params({gX_rho, gV_rho, gT_rho});
-    X_rho.set_formfactor(true, bRho);
+    X_rho.set_formfactor(true, LamRho);
 
     std::vector<amplitude*> X_exchanges = {&X_omega, &X_rho};
     amplitude_sum X(kX, X_exchanges, "#it{X}(3872)");

--- a/executables/XYZ_plots/X3872_low.cpp
+++ b/executables/XYZ_plots/X3872_low.cpp
@@ -38,10 +38,12 @@ int main( int argc, char** argv )
     // Chi_c1(1P)
     double mChi = 3.510;
     reaction_kinematics * kChi = new reaction_kinematics(mChi);
+    kChi->set_JP(1, 1);
 
     // X(3872)
     double mX = 3.87169;
     reaction_kinematics * kX = new reaction_kinematics(mX);
+    kX->set_JP(1, 1);
 
     // Nucleon couplings 
     double gV_omega = 16., gT_omega = 0.;

--- a/executables/XYZ_plots/X3872_low.cpp
+++ b/executables/XYZ_plots/X3872_low.cpp
@@ -47,10 +47,10 @@ int main( int argc, char** argv )
 
     // Nucleon couplings 
     double gV_omega = 16., gT_omega = 0.;
-    double bOmega = 0.68; // Cuttoff of LamOmega = 1.2 GeV
+    double LamOmega = 1.2; // cutoff
 
     double gV_rho = 2.4, gT_rho = 14.6;
-    double bRho = 0.51; // Cuttoff of LamRho = 1.4 GeV
+    double LamRho = 1.4; // cutoff
 
     double gV_phi = -6.2, gT_phi = 2.1;
 
@@ -65,12 +65,12 @@ int main( int argc, char** argv )
     double gChi_omega = 5.2E-4;
     vector_exchange Chi_omega(kChi, mOmega, "#omega");
     Chi_omega.set_params({gChi_omega, gV_omega, gT_omega});
-    Chi_omega.set_formfactor(true, bOmega);
+    Chi_omega.set_formfactor(1, LamOmega);
 
     double gChi_rho = 9.2E-4;
     vector_exchange Chi_rho(kChi, mRho, "#rho");
     Chi_rho.set_params({gChi_rho, gV_rho, gT_rho});
-    Chi_rho.set_formfactor(true, bRho);
+    Chi_rho.set_formfactor(1, LamRho);
 
     double gChi_phi = 4.2E-4;
     vector_exchange Chi_phi(kChi, mPhi, "#phi");
@@ -89,12 +89,12 @@ int main( int argc, char** argv )
     double gX_omega = 8.2E-3;
     vector_exchange X_omega(kX, mOmega, "#omega");
     X_omega.set_params({gX_omega, gV_omega, gT_omega});
-    X_omega.set_formfactor(true, bOmega);
+    X_omega.set_formfactor(1, LamOmega);
 
     double gX_rho = 3.6E-3;
     vector_exchange X_rho(kX, mRho, "#rho");
     X_rho.set_params({gX_rho, gV_rho, gT_rho});
-    X_rho.set_formfactor(true, bRho);
+    X_rho.set_formfactor(1, LamRho);
 
     std::vector<amplitude*> X_exchanges = {&X_omega, &X_rho};
     amplitude_sum X(kX, X_exchanges, "#it{X}(3872)");

--- a/executables/XYZ_plots/X6900.cpp
+++ b/executables/XYZ_plots/X6900.cpp
@@ -54,12 +54,10 @@ int main( int argc, char** argv )
 
     vector_exchange X_psi(kX, mJpsi, "J/#psi exchange, BR = 100%");
     X_psi.set_params({gGam_psi, gV_psi, gT_psi});
-    X_psi.set_scalarX(true);
 
     vector_exchange X_omega(kX, mOmega, "#it{X}(6900) with BR(#it{X #rightarrow #psi#omega}) = 1%");
     X_omega.set_params({gGam_omega, gV_omega, gT_omega});
     X_omega.set_formfactor(true, bOmega);
-    X_omega.set_scalarX(true);
    
     // ---------------------------------------------------------------------------
     // Plotting options

--- a/executables/XYZ_plots/X6900.cpp
+++ b/executables/XYZ_plots/X6900.cpp
@@ -41,6 +41,7 @@ int main( int argc, char** argv )
     // X(6900)
     double mX = 6.900;
     reaction_kinematics * kX = new reaction_kinematics(mX);
+    kX->set_JP(0, 1);
 
     double gV_psi = 1.6E-3, gT_psi = 0.;
     double gX_psi = 5.03;

--- a/executables/XYZ_plots/Y_high.cpp
+++ b/executables/XYZ_plots/Y_high.cpp
@@ -43,15 +43,18 @@ int main( int argc, char** argv )
 
     // J/Psi
     reaction_kinematics * kJpsi = new reaction_kinematics(mJpsi);
+    kJpsi->set_JP(1, -1);
     double R_Jpsi = 1.;
 
     // Psi(2S)
     reaction_kinematics * kPsi2s = new reaction_kinematics(mPsi2S);
+    kPsi2s->set_JP(1, -1);
     double R_Psi2s = 0.55;
 
     // Y(4260)
     double mY = 4.220;
     reaction_kinematics * kY = new reaction_kinematics(mY);
+    kY->set_JP(1, -1);
     double R_Y = 1.55;
 
     // ---------------------------------------------------------------------------

--- a/executables/XYZ_plots/Y_low.cpp
+++ b/executables/XYZ_plots/Y_low.cpp
@@ -44,15 +44,18 @@ int main( int argc, char** argv )
 
     // J/Psi
     reaction_kinematics * kJpsi = new reaction_kinematics(mJpsi);
+    kJpsi->set_JP(1, -1);
     double R_Jpsi = 1.;
 
     // Psi(2S)
     reaction_kinematics * kPsi2s = new reaction_kinematics(mPsi2S);
+    kPsi2s->set_JP(1, -1);
     double R_Psi2s = 0.55;
 
     // Y(4260)
     double mY = 4.220;
     reaction_kinematics * kY = new reaction_kinematics(mY);
+    kY->set_JP(1, -1);
     double R_Y = 1.55;
 
     // ---------------------------------------------------------------------------

--- a/executables/XYZ_plots/Z_high.cpp
+++ b/executables/XYZ_plots/Z_high.cpp
@@ -44,6 +44,7 @@ int main( int argc, char** argv )
   // Zc(3900)
   double mZc = 3.8884; // GeV
   reaction_kinematics * kZc = new reaction_kinematics(mZc);
+  kZc->set_JP(1, 1);
 
   double gc_Psi = 1.91; // psi coupling before VMD scaling
   double gc_Gamma = e * fJpsi * gc_Psi / mJpsi;
@@ -52,6 +53,7 @@ int main( int argc, char** argv )
   // Zb(10610)
   double mZb = 10.6072;
   reaction_kinematics * kZb = new reaction_kinematics(mZb);
+  kZb->set_JP(1, 1);
 
   double gb_Ups1 = 0.49, gb_Ups2 = 3.30, gb_Ups3 = 9.22;
   double gb_Gamma = e * (fUpsilon1S * gb_Ups1 / mUpsilon1S 
@@ -63,6 +65,7 @@ int main( int argc, char** argv )
   // Zb(10650)
   double mZbp = 10.6522;
   reaction_kinematics * kZbp = new reaction_kinematics(mZbp);
+  kZbp->set_JP(1, 1);
 
   double gbp_Ups1 = 0.21, gbp_Ups2 = 1.47, gbp_Ups3 = 4.8;
   double gbp_Gamma = e * (fUpsilon1S * gbp_Ups1 / mUpsilon1S 

--- a/executables/XYZ_plots/Z_low.cpp
+++ b/executables/XYZ_plots/Z_low.cpp
@@ -44,6 +44,7 @@ int main( int argc, char** argv )
   // Zc(3900)
   double mZc = 3.8884; // GeV
   reaction_kinematics * kZc = new reaction_kinematics(mZc);
+  kZc->set_JP(1, 1);
 
   double gc_Psi = 1.91; // psi coupling before VMD scaling
   double gc_Gamma = e * fJpsi * gc_Psi / mJpsi;
@@ -52,6 +53,7 @@ int main( int argc, char** argv )
   // Zb(10610)
   double mZb = 10.6072;
   reaction_kinematics * kZb = new reaction_kinematics(mZb);
+  kZb->set_JP(1, 1);
 
   double gb_Ups1 = 0.49, gb_Ups2 = 3.30, gb_Ups3 = 9.22;
   double gb_Gamma = e * (fUpsilon1S * gb_Ups1 / mUpsilon1S 
@@ -63,6 +65,7 @@ int main( int argc, char** argv )
   // Zb(10650)
   double mZbp = 10.6522;
   reaction_kinematics * kZbp = new reaction_kinematics(mZbp);
+  kZbp->set_JP(1, 1);
 
   double gbp_Ups1 = 0.21, gbp_Ups2 = 1.47, gbp_Ups3 = 4.8;
   double gbp_Gamma = e * (fUpsilon1S * gbp_Ups1 / mUpsilon1S 

--- a/executables/XYZ_plots/primakoff_differential.cpp
+++ b/executables/XYZ_plots/primakoff_differential.cpp
@@ -39,6 +39,7 @@ int main( int argc, char** argv )
     // Uranium
     double mU = 221.6977; // GeV
     reaction_kinematics * kU = new reaction_kinematics(mX, mU, Q2);
+    kU->set_JP(1, 1);
 
     primakoff_effect U(kU, "^{238}U");
     U.set_params({92, 34.48, 3.07, 3.2E-3});
@@ -46,6 +47,7 @@ int main( int argc, char** argv )
     // Tin
     double mSn = 115.3924; // GeV
     reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, Q2);
+    kSn->set_JP(1, 1);
 
     primakoff_effect Sn(kSn, "^{124}Sn");
     Sn.set_params({50, 27.56, 2.73, 3.2E-3});
@@ -53,6 +55,7 @@ int main( int argc, char** argv )
     // Zinc
     double mZn = 65.1202; // GeV
     reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, Q2);
+    kZn->set_JP(1, 1);
 
     primakoff_effect Zn(kZn, "^{70}Zn");
     Zn.set_params({30, 22.34, 2.954, 3.2E-3});

--- a/executables/XYZ_plots/primakoff_differential.cpp
+++ b/executables/XYZ_plots/primakoff_differential.cpp
@@ -38,7 +38,8 @@ int main( int argc, char** argv )
 
     // Uranium
     double mU = 221.6977; // GeV
-    reaction_kinematics * kU = new reaction_kinematics(mX, mU, Q2);
+    reaction_kinematics * kU = new reaction_kinematics(mX, mU, mU);
+    kU->set_Q2(Q2);
     kU->set_JP(1, 1);
 
     primakoff_effect U(kU, "^{238}U");
@@ -46,7 +47,8 @@ int main( int argc, char** argv )
 
     // Tin
     double mSn = 115.3924; // GeV
-    reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, Q2);
+    reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, mSn);
+    kSn->set_Q2(Q2);
     kSn->set_JP(1, 1);
 
     primakoff_effect Sn(kSn, "^{124}Sn");
@@ -54,7 +56,8 @@ int main( int argc, char** argv )
 
     // Zinc
     double mZn = 65.1202; // GeV
-    reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, Q2);
+    reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, mZn);
+    kZn->set_Q2(Q2);
     kZn->set_JP(1, 1);
 
     primakoff_effect Zn(kZn, "^{70}Zn");

--- a/executables/XYZ_plots/primakoff_integrated.cpp
+++ b/executables/XYZ_plots/primakoff_integrated.cpp
@@ -38,7 +38,8 @@ int main( int argc, char** argv )
 
     // Uranium
     double mU = 221.6977;
-    reaction_kinematics * kU = new reaction_kinematics(mX, mU, Q2);
+    reaction_kinematics * kU = new reaction_kinematics(mX, mU, mU);
+    kU->set_Q2(Q2);
     kU->set_JP(1, 1);
 
     primakoff_effect U(kU, "^{238}U");
@@ -46,7 +47,8 @@ int main( int argc, char** argv )
 
     // Tin
     double mSn = 115.3924;
-    reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, Q2);
+    reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, mSn);
+    kSn->set_Q2(Q2);
     kSn->set_JP(1, 1);
 
     primakoff_effect Sn(kSn, "^{124}Sn");
@@ -54,7 +56,8 @@ int main( int argc, char** argv )
 
     // Zinc
     double mZn = 65.1202;
-    reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, Q2);
+    reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, mZn);
+    kZn->set_Q2(Q2);
     kZn->set_JP(1, 1);
 
     primakoff_effect Zn(kZn, "^{70}Zn");

--- a/executables/XYZ_plots/primakoff_integrated.cpp
+++ b/executables/XYZ_plots/primakoff_integrated.cpp
@@ -39,6 +39,7 @@ int main( int argc, char** argv )
     // Uranium
     double mU = 221.6977;
     reaction_kinematics * kU = new reaction_kinematics(mX, mU, Q2);
+    kU->set_JP(1, 1);
 
     primakoff_effect U(kU, "^{238}U");
     U.set_params({92, 34.48, 3.07, 3.2E-3});
@@ -46,6 +47,7 @@ int main( int argc, char** argv )
     // Tin
     double mSn = 115.3924;
     reaction_kinematics * kSn = new reaction_kinematics(mX, mSn, Q2);
+    kSn->set_JP(1, 1);
 
     primakoff_effect Sn(kSn, "^{124}Sn");
     Sn.set_params({50, 27.56, 2.73, 3.2E-3});
@@ -53,6 +55,7 @@ int main( int argc, char** argv )
     // Zinc
     double mZn = 65.1202;
     reaction_kinematics * kZn = new reaction_kinematics(mX, mZn, Q2);
+    kZn->set_JP(1, 1);
 
     primakoff_effect Zn(kZn, "^{70}Zn");
     Zn.set_params({30, 22.34, 2.954, 3.2E-3});

--- a/executables/open_charm/LambdaD.cpp
+++ b/executables/open_charm/LambdaD.cpp
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------
+// Photoproduction cross-sections of the Lambda_c Dbar/D* final state
+// by open charm exchanges 
+//
+// Author:       Daniel Winney (2020)
+// Affiliation:  Joint Physics Analysis Center (JPAC)
+// Email:        dwinney@iu.edu
+// ---------------------------------------------------------------------------
+// References:
+// [1] arXiv:2009.08345v1
+// ---------------------------------------------------------------------------
+
+#include "constants.hpp"
+#include "reaction_kinematics.hpp"
+#include "amplitudes/vector_exchange.hpp"
+#include "amplitudes/dirac_exchange.hpp"
+#include "amplitudes/amplitude_sum.hpp"
+
+#include "photoPlotter.hpp"
+
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+
+using namespace jpacPhoto;
+
+int main( int argc, char** argv )
+{
+    // Set up Kinematics for Dbar LambdaC in final state
+    auto ptr = new reaction_kinematics(mD, mLambdaC, mPro);
+    ptr->set_JP(0, -1);
+
+    // Amplitude
+    double eta = 1.;
+
+    auto dstarEx = new vector_exchange(ptr, mDstar, "D^{*} exchange");
+    dstarEx->set_params({0.134, -13.2, 0.});
+    dstarEx->set_formfactor(2, mDstar + eta * 0.250);
+
+    auto lamcEx = new dirac_exchange(ptr, mLambdaC, "#Lambda_{c} exchange");
+    lamcEx->set_params({sqrt(4.*M_PI*M_ALPHA), -4.3});
+    lamcEx->set_formfactor(2, mLambdaC + eta * 0.250);
+
+    auto sum = new amplitude_sum(ptr, {dstarEx, lamcEx}, "Sum");
+
+    // ---------------------------- -----------------------------------------------
+    // Plotting options
+    // ---------------------------------------------------------------------------
+
+    // which amps to plot
+    std::vector<amplitude*> amps;
+    amps.push_back(dstarEx);
+    amps.push_back(lamcEx);
+    amps.push_back(sum);
+
+    auto plotter = new photoPlotter(amps);
+
+    plotter->N = 30;
+    plotter->PRINT_TO_COMMANDLINE = true;
+    plotter->LAB_ENERGY = true;
+
+    plotter->xmin = 8.5;
+    plotter->xmax = 10.5;
+
+    plotter->ymin = 0.;
+    plotter->ymax = 230.;
+
+    // plotter->SHOW_LEGEND = true;
+    // plotter->xlegend = 0.2;
+    // plotter->ylegend = 0.6;
+
+    plotter->filename  = "open_charm.pdf";
+    plotter->ylabel    = "#it{#sigma(#gamma p #rightarrow #bar{D} #Lambda_{c}^{+})}  [nb]";
+    plotter->xlabel    = "#it{E_{#gamma}}  [GeV]";
+
+    plotter->Plot("integrated_xsection");
+
+    delete ptr;
+    return 1;
+};

--- a/executables/pentaquark/asymmetry_pentaquark.cpp
+++ b/executables/pentaquark/asymmetry_pentaquark.cpp
@@ -144,7 +144,7 @@ int main( int argc, char** argv )
         auto F = [&](double theta)
         {
             double t = ptr->t_man(W*W, theta * deg2rad);
-            return amps[n]->beam_asymmetry_y(W*W, t);
+            return amps[n]->beam_asymmetry_4pi(W*W, t);
         };
 
         std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90.);

--- a/executables/pentaquark/asymmetry_pentaquark.cpp
+++ b/executables/pentaquark/asymmetry_pentaquark.cpp
@@ -38,130 +38,131 @@ using namespace jpacPhoto;
 int main( int argc, char** argv )
 {
 
-  // ---------------------------------------------------------------------------
-  // COMMAND LINE OPTIONS
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // COMMAND LINE OPTIONS
+    // ---------------------------------------------------------------------------
 
-  // Default values
-  double y[2]; bool custom_y = false;
-  double W = 4.45;
-  int N = 200; // how many points to plot
-  bool TENQ = false;
-  std::string filename = "5q_beam_asymmetry.pdf";
+    // Default values
+    double y[2]; bool custom_y = false;
+    double W = 4.45;
+    int N = 200; // how many points to plot
+    bool TENQ = false;
+    std::string filename = "5q_beam_asymmetry.pdf";
 
-  // Parse input string
-  for (int i = 0; i < argc; i++)
-  {
-    if (std::strcmp(argv[i],"-e")==0) W = atof(argv[i+1]);
-    if (std::strcmp(argv[i],"-f")==0) filename = argv[i+1];
-    if (std::strcmp(argv[i],"-10q")==0) TENQ = true;
-    if (std::strcmp(argv[i],"-y")==0)
+    // Parse input string
+    for (int i = 0; i < argc; i++)
     {
-      custom_y = true;
-      y_range(argv[i+1], y);
+        if (std::strcmp(argv[i],"-e")==0) W = atof(argv[i+1]);
+        if (std::strcmp(argv[i],"-f")==0) filename = argv[i+1];
+        if (std::strcmp(argv[i],"-10q")==0) TENQ = true;
+        if (std::strcmp(argv[i],"-y")==0)
+        {
+            custom_y = true;
+            y_range(argv[i+1], y);
+        }
     }
-  }
 
-  // ---------------------------------------------------------------------------
-  // AMPLITUDES
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // AMPLITUDES
+    // ---------------------------------------------------------------------------
 
-  // Set up Kinematics for jpsi in final state
-  reaction_kinematics * ptr = new reaction_kinematics(mJpsi);
+    // Set up Kinematics for jpsi in final state
+    reaction_kinematics * ptr = new reaction_kinematics(mJpsi);
+    ptr->set_JP(1, -1);
 
-  // ---------------------------------------------------------------------------
-  // T - CHANNEL // this is the same for all cases
+    // ---------------------------------------------------------------------------
+    // T - CHANNEL // this is the same for all cases
 
-  // Set up pomeron trajectory
-  // best fit values from [1]
-  linear_trajectory alpha(+1, 0.941, 0.364);
+    // Set up pomeron trajectory
+    // best fit values from [1]
+    linear_trajectory alpha(+1, 0.941, 0.364);
 
-  // Create amplitude with kinematics and trajectory
-  pomeron_exchange background(ptr, &alpha, false, "Background");
+    // Create amplitude with kinematics and trajectory
+    pomeron_exchange background(ptr, &alpha, false, "Background");
 
-  // normalization and t-slope
-  // best fit values from [1]
-  std::vector<double> back_params = {0.379, 0.12};
-  background.set_params(back_params);
+    // normalization and t-slope
+    // best fit values from [1]
+    std::vector<double> back_params = {0.379, 0.12};
+    background.set_params(back_params);
 
-  // ---------------------------------------------------------------------------
-  // S - CHANNEL  // Two different pentaquarks (if -10q == true)
+    // ---------------------------------------------------------------------------
+    // S - CHANNEL  // Two different pentaquarks (if -10q == true)
 
-  // masses and widths from 2015 LHCb paper [2]
-  baryon_resonance P_c4450(ptr, 3, -1, 4.45, 0.040, "P_{c}(4450)");
-  P_c4450.set_params({0.01, .7071});
+    // masses and widths from 2015 LHCb paper [2]
+    baryon_resonance P_c4450(ptr, 3, -1, 4.45, 0.040, "P_{c}(4450)");
+    P_c4450.set_params({0.01, .7071});
 
-  // 1% branching fraction and equal photocouplings for both
-  baryon_resonance P_c4380(ptr, 5, +1, 4.38, 0.205, "P_{c}(4380)");
-  P_c4380.set_params({0.01, .7071});
+    // 1% branching fraction and equal photocouplings for both
+    baryon_resonance P_c4380(ptr, 5, +1, 4.38, 0.205, "P_{c}(4380)");
+    P_c4380.set_params({0.01, .7071});
 
-  // Incoherent sum of the s and t channels
-  amplitude_sum sum(ptr, {&background, &P_c4450, &P_c4380}, "Sum");
+    // Incoherent sum of the s and t channels
+    amplitude_sum sum(ptr, {&background, &P_c4450, &P_c4380}, "Sum");
 
-  // ---------------------------------------------------------------------------
-  // S - CHANNEL  // 1 5q but different BR scenarios (if -10q == false)
+    // ---------------------------------------------------------------------------
+    // S - CHANNEL  // 1 5q but different BR scenarios (if -10q == false)
 
-  baryon_resonance P_c1(ptr, 3, -1, 4.45, 0.040, "1%");
-  P_c1.set_params({0.01, .7071});
+    baryon_resonance P_c1(ptr, 3, -1, 4.45, 0.040, "1%");
+    P_c1.set_params({0.01, .7071});
 
-  baryon_resonance P_c05(ptr, 3, -1, 4.45, 0.040, "0.5%");
-  P_c05.set_params({0.005, .7071});
+    baryon_resonance P_c05(ptr, 3, -1, 4.45, 0.040, "0.5%");
+    P_c05.set_params({0.005, .7071});
 
-  baryon_resonance P_c01(ptr, 3, -1, 4.45, 0.040, "0.1%");
-  P_c01.set_params({0.001, .7071});
+    baryon_resonance P_c01(ptr, 3, -1, 4.45, 0.040, "0.1%");
+    P_c01.set_params({0.001, .7071});
 
-  // Add to the sum
-  amplitude_sum sum1(ptr, {&background, &P_c1}, "1%");
-  amplitude_sum sum2(ptr, {&background, &P_c05}, "0.5%");
-  amplitude_sum sum3(ptr, {&background, &P_c01}, "0.1%");
+    // Add to the sum
+    amplitude_sum sum1(ptr, {&background, &P_c1}, "1%");
+    amplitude_sum sum2(ptr, {&background, &P_c05}, "0.5%");
+    amplitude_sum sum3(ptr, {&background, &P_c01}, "0.1%");
 
 
-  // ---------------------------------------------------------------------------
-  // Choose which scenario to plot
-  std::vector<amplitude*> amps;
-  if (TENQ == true)
-  {
-    amps = {&sum, &background, &P_c4450, &P_c4380};
-  }
-  else
-  {
-    amps = {&background, &sum1, &sum2, &sum3};
-  }
-
-  // ---------------------------------------------------------------------------
-  // You shouldnt need to change anything below this line
-  // ---------------------------------------------------------------------------
-
-  // Plotter objects
-  jpacGraph1D* plotter = new jpacGraph1D();
-
-  // ---------------------------------------------------------------------------
-  // scan over theta
-  for (int n = 0; n < amps.size(); n++)
-  {
-
-    auto F = [&](double theta)
+    // ---------------------------------------------------------------------------
+    // Choose which scenario to plot
+    std::vector<amplitude*> amps;
+    if (TENQ == true)
     {
-      double t = ptr->t_man(W*W, theta * deg2rad);
-      return amps[n]->beam_asymmetry_y(W*W, t);
-    };
+        amps = {&sum, &background, &P_c4450, &P_c4380};
+    }
+    else
+    {
+        amps = {&background, &sum1, &sum2, &sum3};
+    }
 
-    std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90.);
-    plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
-  }
+    // ---------------------------------------------------------------------------
+    // You shouldnt need to change anything below this line
+    // ---------------------------------------------------------------------------
 
-  // Add a header to legend to specify the fixed energy
-  std::ostringstream streamObj;
-  streamObj << std::setprecision(4) << W;
-  plotter->SetLegend(0.2, 0.7, "W = " + streamObj.str() + " GeV");
+    // Plotter objects
+    jpacGraph1D* plotter = new jpacGraph1D();
 
-  plotter->SetXaxis("#theta", 0., 90.);
+    // ---------------------------------------------------------------------------
+    // scan over theta
+    for (int n = 0; n < amps.size(); n++)
+    {
 
-  // To change the range of the Y-axis or the position of the Legend change the arguments here
-  (custom_y == true) ? (plotter->SetYaxis("#Sigma", y[0], y[1])) : (plotter->SetYaxis("#Sigma"));
+        auto F = [&](double theta)
+        {
+            double t = ptr->t_man(W*W, theta * deg2rad);
+            return amps[n]->beam_asymmetry_y(W*W, t);
+        };
+
+        std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90.);
+        plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+    }
+
+    // Add a header to legend to specify the fixed energy
+    std::ostringstream streamObj;
+    streamObj << std::setprecision(4) << W;
+    plotter->SetLegend(0.2, 0.7, "W = " + streamObj.str() + " GeV");
+
+    plotter->SetXaxis("#theta", 0., 90.);
+
+    // To change the range of the Y-axis or the position of the Legend change the arguments here
+    (custom_y == true) ? (plotter->SetYaxis("#Sigma", y[0], y[1])) : (plotter->SetYaxis("#Sigma"));
 
 
-  plotter->Plot(filename.c_str());
+    plotter->Plot(filename.c_str());
 
-  return 1.;
+    return 1.;
 };

--- a/executables/pentaquark/average_asymmetry.cpp
+++ b/executables/pentaquark/average_asymmetry.cpp
@@ -69,34 +69,31 @@ int main( int argc, char** argv )
     auto Pc4457_3m = new baryon_resonance(ptr, 3, -1, 4.4573, 6.4E-3, "P_{c}(4457)");
     Pc4457_3m->set_params({0.01, .7071});
 
-    auto Pc4457_5m = new baryon_resonance(ptr, 5, -1, 4.4573, 6.4E-3, "P_{c}(4457)");
+    auto Pc4457_5m = new baryon_resonance(ptr, 5, 1, 4.4573, 6.4E-3, "P_{c}(4457)");
     Pc4457_5m->set_params({0.01, .7071});
 
 
     // Add to the sum
-    auto sumA = new amplitude_sum (ptr, {background, Pc4312_1m, Pc4440_3m}, "A");
-    auto sumB = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_1m}, "B");
-    auto sumC = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_3p}, "C");
+    auto sumA = new amplitude_sum (ptr, {background, Pc4312_1m, Pc4440_3m, Pc4457_1m}, "A");
+    auto sumB = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_1m, Pc4457_3m}, "B");
+    auto sumC = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_3p, Pc4457_5m}, "C");
 
     // ---------------------------------------------------------------------------
     // Choose which scenario to plot
     std::vector<amplitude*> amps;
     amps.push_back(background);
-    // amps.push_back(sumA);
-    // amps.push_back(sumB);
-    // amps.push_back(sumC);
+    amps.push_back(sumA);
+    amps.push_back(sumB);
+    amps.push_back(sumC);
 
     int N = 100;
     bool PRINT_TO_COMMANDLINE = true;
 
-    double ymax =  1.;
-    double ymin = -0.1;
+    double ymax =  0.2;
+    double ymin = -0.05;
 
     double Emin = E_beam(ptr->Wth()) + EPS;
     double Emax = 12.;
-
-    // double Emin = 10.;
-    // double Emax = 10.1;
 
     std::string filename = "sigma_integrated.pdf";
 
@@ -109,42 +106,47 @@ int main( int argc, char** argv )
 
     // ---------------------------------------------------------------------------
     // scan over theta
-    // for (int n = 0; n < amps.size(); n++)
-    // {
-    //     std::cout << "\nPrinting amplitude " << amps[n]->identifier << ".\n";
+    for (int n = 0; n < amps.size(); n++)
+    {
+        std::cout << "\nPrinting amplitude " << amps[n]->identifier << ".\n";
 
-    //     auto F = [&](double theta)
-    //     {
+        auto F = [&](double theta)
+        {
 
-    //         auto f = [&](double E)
-    //         {
-    //             double W = W_cm(E);
-    //             double t = ptr->t_man(W*W, theta * deg2rad);
-    //             return amps[n]->beam_asymmetry_4pi(W*W, t);
-    //         };
+            auto f = [&](double E)
+            {
+                double W = W_cm(E);
+                double t = ptr->t_man(W*W, theta * deg2rad);
+                return amps[n]->beam_asymmetry_4pi(W*W, t);
+            };
 
-    //         ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
-    //         ROOT::Math::Functor1D wF(f);
-    //         ig.SetFunction(wF);
+            ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
+            ROOT::Math::Functor1D wF(f);
+            ig.SetFunction(wF);
             
-    //         return ig.Integral(Emin, Emax);
-    //     };
+            return ig.Integral(Emin, Emax) / (Emax - Emin);
+        };
 
-    //     std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90., PRINT_TO_COMMANDLINE);
-    //     plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
-    // }
+        std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90., PRINT_TO_COMMANDLINE);
+        plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+    }
 
-    // // Add a header to legend to specify the fixed energy
-    // plotter->SetLegend(0.2, 0.7);
+    // Add a header to legend to specify the fixed energy
+    plotter->SetLegend(0.2, 0.7);
 
-    // plotter->SetXaxis("#theta", 0., 90.);
+    plotter->SetXaxis("#theta", 0., 90.);
 
-    // // To change the range of the Y-axis or the position of the Legend change the arguments here
-    // plotter->SetYaxis("#Sigma integrated over E_{#gamma} = \{th, 12.\}", ymin, ymax);
+    // To change the range of the Y-axis or the position of the Legend change the arguments here
+    plotter->SetYaxis("#Sigma averaged over E_{#gamma}", ymin, ymax);
 
+    std::string file1 = "theta_" + filename;
+    plotter->Plot(file1.c_str());
 
-    // plotter->Plot(filename.c_str());
-
+    // clear
+    plotter->ClearData();
+    
+    // ---------------------------------------------------------------------------
+    // scan over energy
     for (int n = 0; n < amps.size(); n++)
     {
         std::cout << "\nPrinting amplitude " << amps[n]->identifier << ".\n";
@@ -163,7 +165,7 @@ int main( int argc, char** argv )
             
             double t_min = amps[n]->kinematics->t_man(W*W, 0.);
             double t_max = amps[n]->kinematics->t_man(W*W, M_PI);
-            return ig.Integral(t_max, t_min);
+            return ig.Integral(t_max, t_min) / (t_min - t_max);
         };
 
         std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, Emin, Emax, PRINT_TO_COMMANDLINE);
@@ -176,10 +178,10 @@ int main( int argc, char** argv )
     plotter->SetXaxis("E_{#gamma}", Emin, Emax);
 
     // To change the range of the Y-axis or the position of the Legend change the arguments here
-    plotter->SetYaxis("#Sigma integrated over t", ymin, ymax);
+    plotter->SetYaxis("#Sigma averaged over t", ymin, ymax);
 
-
-    plotter->Plot(filename.c_str());
+    std::string file2 = "egam_" + filename;
+    plotter->Plot(file2.c_str());
 
     return 1.;
 };

--- a/executables/pentaquark/integrated_asymmetry.cpp
+++ b/executables/pentaquark/integrated_asymmetry.cpp
@@ -1,0 +1,185 @@
+#include "constants.hpp"
+#include "reaction_kinematics.hpp"
+#include "amplitudes/baryon_resonance.hpp"
+#include "amplitudes/pomeron_exchange.hpp"
+#include "amplitudes/amplitude_sum.hpp"
+
+#include "jpacGraph1D.hpp"
+#include "jpacUtils.hpp"
+
+#include "Math/GSLIntegrator.h"
+#include "Math/IntegrationTypes.h"
+#include "Math/Functor.h"
+
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+
+using namespace jpacPhoto;
+
+int main( int argc, char** argv )
+{
+    // ---------------------------------------------------------------------------
+    // AMPLITUDES
+    // ---------------------------------------------------------------------------
+
+    // Set up Kinematics for jpsi in final state
+    auto ptr = new reaction_kinematics(mJpsi);
+    ptr->set_JP(1, -1);
+
+    // ---------------------------------------------------------------------------
+    // T - CHANNEL // this is the same for all cases
+
+    // Set up pomeron trajectory
+    // best fit values from [1]
+    auto alpha = new linear_trajectory(+1, 0.941, 0.364);
+
+    // Create amplitude with kinematics and trajectory
+    auto background = new pomeron_exchange(ptr, alpha, false, "Background");
+
+    // normalization and t-slope
+    // best fit values from [1]
+    std::vector<double> back_params = {0.379, 0.12};
+    background->set_params(back_params);
+
+    // ---------------------------------------------------------------------------
+    // S - CHANNEL 
+
+    // Pc4312
+    auto Pc4312_1m = new baryon_resonance(ptr, 1, -1, 4.3119, 9.8E-3, "P_{c}(4312)");
+    Pc4312_1m->set_params({0.01, .7071});
+
+    auto Pc4312_3m = new baryon_resonance(ptr, 3, -1, 4.3119, 9.8E-3, "P_{c}(4312)");
+    Pc4312_3m->set_params({0.01, .7071});
+
+    // Pc4440
+    auto Pc4440_1m = new baryon_resonance(ptr, 1, -1, 4.4403, 20.6E-3, "P_{c}(4440)");
+    Pc4440_1m->set_params({0.01, .7071});
+
+    auto Pc4440_3m = new baryon_resonance(ptr, 3, -1, 4.4403, 20.6E-3, "P_{c}(4440)");
+    Pc4440_3m->set_params({0.01, .7071});
+
+    auto Pc4440_3p = new baryon_resonance(ptr, 3, +1, 4.4403, 20.6E-3, "P_{c}(4440)");
+    Pc4440_3p->set_params({0.01, .7071});
+
+    // Pc4457
+    auto Pc4457_1m = new baryon_resonance(ptr, 1, -1, 4.4573, 6.4E-3, "P_{c}(4457)");
+    Pc4457_1m->set_params({0.01, .7071});
+
+    auto Pc4457_3m = new baryon_resonance(ptr, 3, -1, 4.4573, 6.4E-3, "P_{c}(4457)");
+    Pc4457_3m->set_params({0.01, .7071});
+
+    auto Pc4457_5m = new baryon_resonance(ptr, 5, -1, 4.4573, 6.4E-3, "P_{c}(4457)");
+    Pc4457_5m->set_params({0.01, .7071});
+
+
+    // Add to the sum
+    auto sumA = new amplitude_sum (ptr, {background, Pc4312_1m, Pc4440_3m}, "A");
+    auto sumB = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_1m}, "B");
+    auto sumC = new amplitude_sum (ptr, {background, Pc4312_3m, Pc4440_3p}, "C");
+
+    // ---------------------------------------------------------------------------
+    // Choose which scenario to plot
+    std::vector<amplitude*> amps;
+    amps.push_back(background);
+    // amps.push_back(sumA);
+    // amps.push_back(sumB);
+    // amps.push_back(sumC);
+
+    int N = 100;
+    bool PRINT_TO_COMMANDLINE = true;
+
+    double ymax =  1.;
+    double ymin = -0.1;
+
+    double Emin = E_beam(ptr->Wth()) + EPS;
+    double Emax = 12.;
+
+    // double Emin = 10.;
+    // double Emax = 10.1;
+
+    std::string filename = "sigma_integrated.pdf";
+
+    // ---------------------------------------------------------------------------
+    // You shouldnt need to change anything below this line
+    // ---------------------------------------------------------------------------
+
+    // Plotter objects
+    jpacGraph1D* plotter = new jpacGraph1D();
+
+    // ---------------------------------------------------------------------------
+    // scan over theta
+    // for (int n = 0; n < amps.size(); n++)
+    // {
+    //     std::cout << "\nPrinting amplitude " << amps[n]->identifier << ".\n";
+
+    //     auto F = [&](double theta)
+    //     {
+
+    //         auto f = [&](double E)
+    //         {
+    //             double W = W_cm(E);
+    //             double t = ptr->t_man(W*W, theta * deg2rad);
+    //             return amps[n]->beam_asymmetry_4pi(W*W, t);
+    //         };
+
+    //         ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
+    //         ROOT::Math::Functor1D wF(f);
+    //         ig.SetFunction(wF);
+            
+    //         return ig.Integral(Emin, Emax);
+    //     };
+
+    //     std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, 0., 90., PRINT_TO_COMMANDLINE);
+    //     plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+    // }
+
+    // // Add a header to legend to specify the fixed energy
+    // plotter->SetLegend(0.2, 0.7);
+
+    // plotter->SetXaxis("#theta", 0., 90.);
+
+    // // To change the range of the Y-axis or the position of the Legend change the arguments here
+    // plotter->SetYaxis("#Sigma integrated over E_{#gamma} = \{th, 12.\}", ymin, ymax);
+
+
+    // plotter->Plot(filename.c_str());
+
+    for (int n = 0; n < amps.size(); n++)
+    {
+        std::cout << "\nPrinting amplitude " << amps[n]->identifier << ".\n";
+
+        auto F = [&](double egam)
+        {
+            double W = W_cm(egam);
+            auto f = [&](double t)
+            {
+                return amps[n]->beam_asymmetry_4pi(W*W, t);
+            };
+
+            ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
+            ROOT::Math::Functor1D wF(f);
+            ig.SetFunction(wF);
+            
+            double t_min = amps[n]->kinematics->t_man(W*W, 0.);
+            double t_max = amps[n]->kinematics->t_man(W*W, M_PI);
+            return ig.Integral(t_max, t_min);
+        };
+
+        std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, Emin, Emax, PRINT_TO_COMMANDLINE);
+        plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+    }
+
+    // Add a header to legend to specify the fixed energy
+    plotter->SetLegend(0.2, 0.7);
+
+    plotter->SetXaxis("E_{#gamma}", Emin, Emax);
+
+    // To change the range of the Y-axis or the position of the Legend change the arguments here
+    plotter->SetYaxis("#Sigma integrated over t", ymin, ymax);
+
+
+    plotter->Plot(filename.c_str());
+
+    return 1.;
+};

--- a/executables/pentaquark/polarized_pentaquark.cpp
+++ b/executables/pentaquark/polarized_pentaquark.cpp
@@ -39,124 +39,126 @@ using namespace jpacPhoto;
 
 int main( int argc, char** argv )
 {
-  // ---------------------------------------------------------------------------
-  // COMMAND LINE OPTIONS
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // COMMAND LINE OPTIONS
+    // ---------------------------------------------------------------------------
 
-  // Default values
-  double theta = 0.;
-  double y[2]; bool custom_y = false;
-  int N = 100; // how many points to plot
-  double max = 5.;
-  std::string filename = "polarized_5q.pdf";
-  std::string observable = "dxs", ylabel;
+    // Default values
+    double theta = 0.;
+    double y[2]; bool custom_y = false;
+    int N = 100; // how many points to plot
+    double max = 5.;
+    std::string filename = "polarized_5q.pdf";
+    std::string observable = "dxs", ylabel;
 
-  // Parse input string
-  for (int i = 0; i < argc; i++)
-  {
-    if (std::strcmp(argv[i],"-c")==0) theta = atof(argv[i+1]);
-    if (std::strcmp(argv[i],"-m")==0) max = atof(argv[i+1]);
-    if (std::strcmp(argv[i],"-f")==0) filename = argv[i+1];
-    if (std::strcmp(argv[i],"-o")==0) observable = argv[i+1];
-    if (std::strcmp(argv[i],"-y")==0)
+    // Parse input string
+    for (int i = 0; i < argc; i++)
     {
-      custom_y = true;
-      y_range(argv[i+1], y);
+        if (std::strcmp(argv[i],"-c")==0) theta = atof(argv[i+1]);
+        if (std::strcmp(argv[i],"-m")==0) max = atof(argv[i+1]);
+        if (std::strcmp(argv[i],"-f")==0) filename = argv[i+1];
+        if (std::strcmp(argv[i],"-o")==0) observable = argv[i+1];
+        if (std::strcmp(argv[i],"-y")==0)
+        {
+            custom_y = true;
+            y_range(argv[i+1], y);
+        }
     }
-  }
 
-  // ---------------------------------------------------------------------------
-  // AMPLITUDES
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // AMPLITUDES
+    // ---------------------------------------------------------------------------
 
-  // Set up Kinematics
-  reaction_kinematics * ptr = new reaction_kinematics(mJpsi);
+    // Set up Kinematics
+    reaction_kinematics * ptr = new reaction_kinematics(mJpsi);
+    ptr->set_JP(1, -1);
 
-  // ---------------------------------------------------------------------------
-  // S - CHANNEL
+    // ---------------------------------------------------------------------------
+    // S - CHANNEL
 
-  // Two different pentaquarks
-  // masses and widths from 2015 LHCb paper [2]
-  baryon_resonance P_c4450(ptr, 3, -1, 4.45, 0.040, "P_{c}(4450)");
-  P_c4450.set_params({0.01, .7071}); // 2% branching fraction and equal photocouplings
+    // Two different pentaquarks
+    // masses and widths from 2015 LHCb paper [2]
+    baryon_resonance P_c4450(ptr, 1, 1, 4.45, 0.040, "P_{c}(4450)");
+    P_c4450.set_params({0.01, .7071}); // 2% branching fraction and equal photocouplings
 
-  baryon_resonance P_c4380(ptr, 5, +1, 4.38, 0.205, "P_{c}(4380)");
-  P_c4380.set_params({0.01, .7071}); // 2% branching fraction and equal photocouplings
+    baryon_resonance P_c4380(ptr, 5, +1, 4.38, 0.205, "P_{c}(4380)");
+    P_c4380.set_params({0.01, .7071}); // 2% branching fraction and equal photocouplings
 
-  // ---------------------------------------------------------------------------
-  // T - CHANNEL
+    // ---------------------------------------------------------------------------
+    // T - CHANNEL
 
-  // Set up pomeron trajectory
-  // Best fit values from [1]
-  linear_trajectory alpha(+1, 0.941, 0.364, "pomeron");
+    // Set up pomeron trajectory
+    // Best fit values from [1]
+    linear_trajectory alpha(+1, 0.941, 0.364, "pomeron");
 
-  // Create amplitude with kinematics and trajectory
-  pomeron_exchange background(ptr, &alpha, false, "Background");
+    // Create amplitude with kinematics and trajectory
+    pomeron_exchange background(ptr, &alpha, false, "Background");
 
-  // normalization and t-slope
-  background.set_params({0.379, 0.12});
+    // normalization and t-slope
+    background.set_params({0.379, 0.12});
 
-  // ---------------------------------------------------------------------------
-  // SUM
-  // ---------------------------------------------------------------------------
-  // Incoherent sum of the s and t channels
-  amplitude_sum sum5q(ptr, {&background, &P_c4450}, "5q Sum");
-  amplitude_sum sum10q(ptr, {&background, &P_c4450, &P_c4380}, "10q Sum");
+    // ---------------------------------------------------------------------------
+    // SUM
+    // ---------------------------------------------------------------------------
+    // Incoherent sum of the s and t channels
+    amplitude_sum sum5q(ptr, {&background, &P_c4450}, "5q Sum");
+    amplitude_sum sum10q(ptr, {&background, &P_c4450, &P_c4380}, "10q Sum");
 
-  std::vector<amplitude*> amps = {&background, &sum5q, &sum10q};
+    std::vector<amplitude*> amps = {&background, &sum5q, &sum10q};
 
-  // ---------------------------------------------------------------------------
-  // You shouldnt need to change anything below this line
-  // ---------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // You shouldnt need to change anything below this line
+    // ---------------------------------------------------------------------------
 
-  // Plotter objects
-  jpacGraph1D* plotter = new jpacGraph1D();
+    // Plotter objects
+    jpacGraph1D* plotter = new jpacGraph1D();
 
-  // ---------------------------------------------------------------------------
-  // scan over energy
-  for (int n = 0; n < amps.size(); n++)
-  {
-    // find the desired observable
-    auto F = [&](double W)
+    // ---------------------------------------------------------------------------
+    // scan over energy
+    for (int n = 0; n < amps.size(); n++)
     {
-      double t = ptr->t_man(W*W, theta * deg2rad);
-      if (observable == "dxs")
-      {
-        ylabel = "d#sigma/dt    (nb GeV^{-2})";
-        return amps[n]->differential_xsection(W*W, t);
-      }
-      else if (observable == "kll")
-      {
-        ylabel = "K_{LL}";
-        return amps[n]->K_LL(W*W, t);
-      }
-      else if (observable == "all")
-      {
-        ylabel = "A_{LL}";
-        return amps[n]->A_LL(W*W, t);
-      }
-      else
-      {
-        std::cout << "invalid observable passed. Quitting.... \n"; exit(0);
-      }
-    };
+        // find the desired observable
+        auto F = [&](double W)
+        {
+            double t = ptr->t_man(W*W, theta * deg2rad);
+            if (observable == "dxs")
+            {
+                ylabel = "d#sigma/dt    (nb GeV^{-2})";
+                return amps[n]->differential_xsection(W*W, t);
+            }
+            else if (observable == "kll")
+            {
+                ylabel = "K_{LL}";
+                return amps[n]->K_LL(W*W, t);
+            }
+            else if (observable == "all")
+            {
+                ylabel = "A_{LL}";
+                return amps[n]->A_LL(W*W, t);
+            }
+            else
+            {
+                std::cout << "invalid observable passed. Quitting.... \n"; exit(0);
+            }
+        };
 
-    std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, sqrt(ptr->sth()) + 0.01, max);
-    plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
-  }
+        std::array<std::vector<double>, 2> x_fx = vec_fill(N, F, sqrt(ptr->sth()) + 0.01, max);
+        plotter->AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+    }
 
-  // Add a header to legend to specify the fixed energy
-  std::ostringstream streamObj;
-  streamObj << std::setprecision(2) << theta;
-  plotter->SetLegend(0.2, 0.7, "#theta = " + streamObj.str());
-  // X axis
-  plotter->SetXaxis("W  (GeV)", sqrt(ptr->sth()) + 0.01, max);
+    // Add a header to legend to specify the fixed energy
+    std::ostringstream streamObj;
+    streamObj << std::setprecision(2) << theta;
+    plotter->SetLegend(0.2, 0.7, "#theta = " + streamObj.str());
 
-  // To change the range of the Y-axis or the position of the Legend change the arguments here
-  (custom_y == true) ? (plotter->SetYaxis(ylabel, y[0], y[1])) : (plotter->SetYaxis(ylabel));
+    // X axis
+    plotter->SetXaxis("W  (GeV)", sqrt(ptr->sth()) + 0.01, max);
+
+    // To change the range of the Y-axis or the position of the Legend change the arguments here
+    (custom_y == true) ? (plotter->SetYaxis(ylabel, y[0], y[1])) : (plotter->SetYaxis(ylabel));
 
 
-  plotter->Plot(filename);
+    plotter->Plot(filename);
 
-return 1.;
+    return 1.;
 };

--- a/executables/pentaquark/pomeron_compare.cpp
+++ b/executables/pentaquark/pomeron_compare.cpp
@@ -1,0 +1,76 @@
+#include "constants.hpp"
+#include "reaction_kinematics.hpp"
+#include "amplitudes/pomeron_exchange.hpp"
+
+#include "photoPlotter.hpp"
+
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+
+using namespace jpacPhoto;
+
+int main( int argc, char** argv )
+{
+    // ---------------------------------------------------------------------------
+    // AMPLITUDES
+    // ---------------------------------------------------------------------------
+
+    // Set up Kinematics for jpsi in final state
+    auto * ptr = new reaction_kinematics(mJpsi);
+    ptr->set_JP(1, -1);
+
+    // ---------------------------------------------------------------------------
+    // Our amplitude
+
+    auto alpha1 = new linear_trajectory(+1, 0.941, 0.364);
+    auto background1 = new pomeron_exchange(ptr, alpha1, 0, "JPAC");
+
+    // Normalization and t-slope
+    background1->set_params({0.379, 0.12});
+
+
+    // ---------------------------------------------------------------------------
+    // Wang et al. amplitude
+
+    auto alpha2 = new linear_trajectory(+1, 1. - 0.08, 0.25);
+    auto background2 = new pomeron_exchange(ptr, alpha2, 2, "Wang et al.");
+
+    // Pomeron-charm coupling and cutoff
+    background2->set_params({sqrt(0.8), 1.2});
+
+
+    // ---------------------------- -----------------------------------------------
+    // Plotting options
+    // ---------------------------------------------------------------------------
+
+    // which amps to plot
+    std::vector<amplitude*> amps;
+    amps.push_back(background1);
+    amps.push_back(background2);
+
+    auto plotter = new photoPlotter(amps);
+
+    plotter->N = 30;
+    plotter->PRINT_TO_COMMANDLINE = true;
+    plotter->LAB_ENERGY = true;
+
+    plotter->xmin = E_beam(ptr->Wth()) + EPS;
+    plotter->xmax = 12.;
+
+    plotter->ymin = 0.;
+    plotter->ymax = 3.5;
+
+    plotter->SHOW_LEGEND = true;
+    plotter->xlegend = 0.2;
+    plotter->ylegend = 0.6;
+
+    plotter->filename  = "jpsi_compare.pdf";
+    plotter->ylabel    = "#it{#sigma(#gamma p #rightarrow J/#psi p)}  [nb]";
+    plotter->xlabel    = "#it{E_{#gamma}}  [GeV]";
+
+    plotter->Plot("integrated_xsection");
+
+    delete ptr, alpha1, alpha2, background1, background2, plotter;
+    return 1;
+};

--- a/executables/photoPlotter.hpp
+++ b/executables/photoPlotter.hpp
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------
+// Wrapper for the jpacGraph1D class to get rid of copying the same code snippets
+//
+// Author:       Daniel Winney (2020)
+// Affiliation:  Joint Physics Analysis Center (JPAC)
+// Email:        dwinney@iu.edu
+// ---------------------------------------------------------------------------
+
+#ifndef _PHOTOPLOT_
+#define _PHOTOPLOT_
+
+#include "jpacGraph1D.hpp"
+#include "jpacUtils.hpp"
+
+#include "reaction_kinematics.hpp"
+#include "amplitudes/amplitude.hpp"
+
+#include <vector>
+#include <string>
+
+namespace jpacPhoto
+{
+    class photoPlotter : public jpacGraph1D
+    {
+        public:
+        
+        // default constructor
+        photoPlotter( std::vector<amplitude*> amps_)
+        : amps(amps_)
+        {};
+        
+        int N = 20;
+        bool PRINT_TO_COMMANDLINE = true;
+        bool LAB_ENERGY = false;
+        double xmin, xmax, ymin, ymax;
+        std::string xlabel, ylabel, filename;
+
+        void plot_integrated_xsection()
+        {
+            
+            for (int n = 0; n < amps.size(); n++)
+            {
+                std::cout << std::endl << "Printing amplitude: " << amps[n]->identifier << "\n";
+    
+                double th;
+                (LAB_ENERGY) ? (th = E_beam(amps[n]->kinematics->Wth())) : (th = amps[n]->kinematics->Wth());
+
+                auto F = [&](double x)
+                {
+                    double W;
+                    (LAB_ENERGY) ? (W = W_cm(x)) : (W = x);
+                    return amps[n]->integrated_xsection(W*W);
+                };
+
+                std::array<std::vector<double>, 2> x_fx;
+                if (xmin < th)
+                {
+                    x_fx = vec_fill(N, F, th + EPS, xmax, PRINT_TO_COMMANDLINE);
+                }
+                else
+                {
+                    x_fx = vec_fill(N, F, xmin, xmax, PRINT_TO_COMMANDLINE);
+                }
+
+                AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+            }
+
+            SetXaxis(xlabel, xmin, xmax);
+            SetYaxis(ylabel, ymin, ymax);
+            SetLegend(false);
+
+            // Output to file
+            Plot(filename);
+        };
+
+        void plot_differential_xsection(double theta)
+        {
+            
+            for (int n = 0; n < amps.size(); n++)
+            {
+                std::cout << std::endl << "Printing amplitude: " << amps[n]->identifier << "\n";
+    
+                double th;
+                (LAB_ENERGY) ? (th = E_beam(amps[n]->kinematics->Wth())) : (th = amps[n]->kinematics->Wth());
+
+                auto F = [&](double x)
+                {
+                    double W;
+                    (LAB_ENERGY) ? (W = W_cm(x)) : (W = x);
+                    double t = amps[n]->kinematics->t_man(W*W, theta * deg2rad);
+                    return amps[n]->differential_xsection(W*W, t);
+                };
+
+                std::array<std::vector<double>, 2> x_fx;
+                if (xmin < th)
+                {
+                    x_fx = vec_fill(N, F, th + EPS, xmax, PRINT_TO_COMMANDLINE);
+                }
+                else
+                {
+                    x_fx = vec_fill(N, F, xmin, xmax, PRINT_TO_COMMANDLINE);
+                }
+
+                AddEntry(x_fx[0], x_fx[1], amps[n]->identifier);
+            }
+
+            SetXaxis(xlabel, xmin, xmax);
+            SetYaxis(ylabel, ymin, ymax);
+            SetLegend(false);
+
+            // Output to file
+            Plot(filename);
+        };
+
+        private:
+        std::vector<amplitude*> amps;
+    }; 
+};
+
+#endif

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -27,20 +27,16 @@
 
 #include <string>
 #include <array>
+#include <algorithm>
 
 namespace jpacPhoto
 {
   class amplitude
   {
   public:
-    // Constructor with only a kinematics object
-    amplitude(reaction_kinematics * xkinem)
-    : kinematics(xkinem)
-    {};
-
-    // Constructor with an amplitude id and number of parameters specified
-    amplitude(reaction_kinematics * xkinem, std::string id, int N)
-    : kinematics(xkinem), identifier(id), Nparams(N)
+    // Constructor with an amplitude id
+    amplitude(reaction_kinematics * xkinem, std::string id = "")
+    : kinematics(xkinem), identifier(id)
     {};
 
     // Kinematics object for thresholds and etc.
@@ -87,7 +83,7 @@ namespace jpacPhoto
     // If helicity amplitudes have already been generated for a value of mV, s, t 
     // store them
     bool CACHED = false;
-    double cached_mVec2 = 0., cached_s = 0., cached_t = 0.;
+    double cached_mX2 = 0., cached_s = 0., cached_t = 0.;
     std::array<std::complex<double>, 24> cached_helicity_amplitude;
 
     void check_cache(double _s, double _t);
@@ -95,55 +91,67 @@ namespace jpacPhoto
     // ---------------------------------------------------------------------------
     // Nparams error message
     int Nparams = 0;
-    void check_Nparams(std::vector<double> params)
+    inline void check_Nparams(std::vector<double> params)
     {
       if (params.size() != Nparams)
       {
         std::cout << "\nWarning! Invalid number of parameters (" << params.size() << ") passed to " << identifier << ".\n";
       }
-    }
+    };
 
+    // ---------------------------------------------------------------------------
+    // Allowed JP error message
+    std::vector<int> allowed_JP;
+    inline void check_JP(int _JP)
+    {
+      if (std::find(allowed_JP.begin(), allowed_JP.end(), _JP) == allowed_JP.end())
+      {
+        std::cout << "\nError! Invalid JP (" << _JP << ") passed to " << identifier << ".\n";
+        exit(0);
+      }      
+    };
+  
     // ---------------------------------------------------------------------------
     // Aliases for the above observables with option to change the produced meson mass
     inline double probability_distribution(double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return probability_distribution(s, t);
     };
 
     inline double differential_xsection(double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return differential_xsection(s, t);
     };
 
     inline double integrated_xsection(double M2, double s)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return integrated_xsection(s);
     };
 
     inline std::complex<double> SDME(int alpha, int lam, int lamp, double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return SDME(alpha, lam, lamp, s, t);
     };
 
     inline double beam_asymmetry_y(double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return beam_asymmetry_y(s, t);
     };
 
     inline double beam_asymmetry_4pi(double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return beam_asymmetry_4pi(s, t);
     };
 
     inline double parity_asymmetry(double M2, double s, double t)
     {
-      kinematics->set_mV2(M2);
+      kinematics->set_mX2(M2);
       return parity_asymmetry(s, t);
     };
   };

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -26,7 +26,6 @@
 #include "Math/Functor.h"
 
 #include <string>
-#include <array>
 #include <algorithm>
 
 namespace jpacPhoto
@@ -50,7 +49,7 @@ namespace jpacPhoto
 
     // How the calculate the helicity amplitude
     // Must be given a specific implementation in a user derived class
-    virtual std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t) = 0;
+    virtual std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t) = 0;
 
     // ---------------------------------------------------------------------------
     // Observables
@@ -84,16 +83,17 @@ namespace jpacPhoto
     // store them
     bool CACHED = false;
     double cached_mX2 = 0., cached_s = 0., cached_t = 0.;
-    std::array<std::complex<double>, 24> cached_helicity_amplitude;
+    std::vector<std::complex<double>> cached_helicity_amplitude;
 
     void check_cache(double _s, double _t);
 
     // ---------------------------------------------------------------------------
-    // Nparams error message
-    int Nparams = 0;
-    inline void check_Nparams(std::vector<double> params)
+    // nParams error message
+    int nParams = 0;
+    inline void set_nParams(int N){ nParams = N; };
+    inline void check_nParams(std::vector<double> params)
     {
-      if (params.size() != Nparams)
+      if (params.size() != nParams)
       {
         std::cout << "\nWarning! Invalid number of parameters (" << params.size() << ") passed to " << identifier << ".\n";
       }

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -33,8 +33,13 @@ namespace jpacPhoto
     class amplitude
     {
         public:
-        // Constructor with an amplitude id
+
         amplitude(reaction_kinematics * xkinem, std::string id = "")
+        : kinematics(xkinem), identifier(id)
+        {};
+
+        // Constructor with nParams for backward compatibility (now depricated)
+        amplitude(reaction_kinematics * xkinem, int n = 0, std::string id = "")
         : kinematics(xkinem), identifier(id)
         {};
 

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -33,13 +33,8 @@ namespace jpacPhoto
     class amplitude
     {
         public:
-
-        amplitude(reaction_kinematics * xkinem, std::string id = "")
-        : kinematics(xkinem), identifier(id)
-        {};
-
         // Constructor with nParams for backward compatibility (now depricated)
-        amplitude(reaction_kinematics * xkinem, int n = 0, std::string id = "")
+        amplitude(reaction_kinematics * xkinem, std::string id = "", int n = 0)
         : kinematics(xkinem), identifier(id)
         {};
 

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -100,14 +100,14 @@ namespace jpacPhoto
         };
 
         // ---------------------------------------------------------------------------
-        // Allowed JP error message
-        std::vector<std::array<int,2>> allowedJP;
+        // Each amplitude must supply a function which returns a vector of allowed 2-tuples {J, P}
+        virtual std::vector<std::array<int,2>> allowedJP() = 0;
         
-        // 
-        inline void add_allowedJP(std::array<int,2> x){ allowedJP.push_back(x); };
+        // Allowed JP error message
         inline void check_JP(std::array<int,2> _JP)
         {
-            if (std::find(allowedJP.begin(), allowedJP.end(), _JP) == allowedJP.end())
+           std::vector<std::array<int,2>> allowed_JP = allowedJP();
+            if (std::find(allowed_JP.begin(), allowed_JP.end(), _JP) == allowed_JP.end())
             {
                 std::cout << "Error! Amplitude for spin: " << _JP[0] << " and parity " << _JP[1] << " for " << identifier << " unavailable.\n";
                 exit(0);

--- a/include/amplitudes/amplitude.hpp
+++ b/include/amplitudes/amplitude.hpp
@@ -30,131 +30,134 @@
 
 namespace jpacPhoto
 {
-  class amplitude
-  {
-  public:
-    // Constructor with an amplitude id
-    amplitude(reaction_kinematics * xkinem, std::string id = "")
-    : kinematics(xkinem), identifier(id)
-    {};
-
-    // Kinematics object for thresholds and etc.
-    reaction_kinematics * kinematics;
-
-    // saved energies and angle 
-    double s, t, theta;
-
-    // Some saveable string by which to identify the amplitude
-    std::string identifier;
-
-    // How the calculate the helicity amplitude
-    // Must be given a specific implementation in a user derived class
-    virtual std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t) = 0;
-
-    // ---------------------------------------------------------------------------
-    // Observables
-    // Evaluatable in terms of s and t or an event object (see reaction_kinematics.hpp)
-
-    // Modulus of the amplitude summed over all helicity combinations
-    double probability_distribution(double s, double t);
-
-    // Differential and total cross-section
-    double differential_xsection(double s, double t);
-
-    // integrated crossection
-    double integrated_xsection(double s);
-
-    // Spin asymmetries
-    double A_LL(double s, double t); // Beam and target
-    double K_LL(double s, double t); // Beam and recoil
-
-    // Spin density matrix elements
-    std::complex<double> SDME(int alpha, int lam, int lamp, double s, double t);
-
-    // Beam Asymmetries
-    double beam_asymmetry_y(double s, double t);    // Along the y direction
-    double beam_asymmetry_4pi(double s, double t);  // integrated along phi
-
-    // Parity asymmetry
-    double parity_asymmetry(double s, double t);
-
-    // ---------------------------------------------------------------------------
-    // If helicity amplitudes have already been generated for a value of mV, s, t 
-    // store them
-    bool CACHED = false;
-    double cached_mX2 = 0., cached_s = 0., cached_t = 0.;
-    std::vector<std::complex<double>> cached_helicity_amplitude;
-
-    void check_cache(double _s, double _t);
-
-    // ---------------------------------------------------------------------------
-    // nParams error message
-    int nParams = 0;
-    inline void set_nParams(int N){ nParams = N; };
-    inline void check_nParams(std::vector<double> params)
+    class amplitude
     {
-      if (params.size() != nParams)
-      {
-        std::cout << "\nWarning! Invalid number of parameters (" << params.size() << ") passed to " << identifier << ".\n";
-      }
-    };
+        public:
+        // Constructor with an amplitude id
+        amplitude(reaction_kinematics * xkinem, std::string id = "")
+        : kinematics(xkinem), identifier(id)
+        {};
 
-    // ---------------------------------------------------------------------------
-    // Allowed JP error message
-    std::vector<int> allowed_JP;
-    inline void check_JP(int _JP)
-    {
-      if (std::find(allowed_JP.begin(), allowed_JP.end(), _JP) == allowed_JP.end())
-      {
-        std::cout << "\nError! Invalid JP (" << _JP << ") passed to " << identifier << ".\n";
-        exit(0);
-      }      
-    };
-  
-    // ---------------------------------------------------------------------------
-    // Aliases for the above observables with option to change the produced meson mass
-    inline double probability_distribution(double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return probability_distribution(s, t);
-    };
+        // Kinematics object for thresholds and etc.
+        reaction_kinematics * kinematics;
 
-    inline double differential_xsection(double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return differential_xsection(s, t);
-    };
+        // saved energies and angle 
+        double s, t, theta;
 
-    inline double integrated_xsection(double M2, double s)
-    {
-      kinematics->set_mX2(M2);
-      return integrated_xsection(s);
-    };
+        // Some saveable string by which to identify the amplitude
+        std::string identifier;
 
-    inline std::complex<double> SDME(int alpha, int lam, int lamp, double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return SDME(alpha, lam, lamp, s, t);
-    };
+        // How the calculate the helicity amplitude
+        // Must be given a specific implementation in a user derived class
+        virtual std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t) = 0;
 
-    inline double beam_asymmetry_y(double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return beam_asymmetry_y(s, t);
-    };
+        // ---------------------------------------------------------------------------
+        // Observables
+        // Evaluatable in terms of s and t or an event object (see reaction_kinematics.hpp)
 
-    inline double beam_asymmetry_4pi(double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return beam_asymmetry_4pi(s, t);
-    };
+        // Modulus of the amplitude summed over all helicity combinations
+        double probability_distribution(double s, double t);
 
-    inline double parity_asymmetry(double M2, double s, double t)
-    {
-      kinematics->set_mX2(M2);
-      return parity_asymmetry(s, t);
+        // Differential and total cross-section
+        double differential_xsection(double s, double t);
+
+        // integrated crossection
+        double integrated_xsection(double s);
+
+        // Spin asymmetries
+        double A_LL(double s, double t); // Beam and target
+        double K_LL(double s, double t); // Beam and recoil
+
+        // Spin density matrix elements
+        std::complex<double> SDME(int alpha, int lam, int lamp, double s, double t);
+
+        // Beam Asymmetries
+        double beam_asymmetry_y(double s, double t);    // Along the y direction
+        double beam_asymmetry_4pi(double s, double t);  // integrated along phi
+
+        // Parity asymmetry
+        double parity_asymmetry(double s, double t);
+
+        // ---------------------------------------------------------------------------
+        // If helicity amplitudes have already been generated for a value of mV, s, t 
+        // store them
+        bool CACHED = false;
+        double cached_mX2 = 0., cached_s = 0., cached_t = 0.;
+        std::vector<std::complex<double>> cached_helicity_amplitude;
+
+        void check_cache(double _s, double _t);
+
+        // ---------------------------------------------------------------------------
+        // nParams error message
+        int nParams = 0;
+        inline void set_nParams(int N){ nParams = N; };
+        inline void check_nParams(std::vector<double> params)
+        {
+            if (params.size() != nParams)
+            {
+                std::cout << "\nWarning! Invalid number of parameters (" << params.size() << ") passed to " << identifier << ".\n";
+            }
+        };
+
+        // ---------------------------------------------------------------------------
+        // Allowed JP error message
+        std::vector<std::array<int,2>> allowedJP;
+        
+        // 
+        inline void add_allowedJP(std::array<int,2> x){ allowedJP.push_back(x); };
+        inline void check_JP(std::array<int,2> _JP)
+        {
+            if (std::find(allowedJP.begin(), allowedJP.end(), _JP) == allowedJP.end())
+            {
+                std::cout << "Error! Amplitude for spin: " << _JP[0] << " and parity " << _JP[1] << " for " << identifier << " unavailable.\n";
+                exit(0);
+            }      
+        };
+
+        // ---------------------------------------------------------------------------
+        // Aliases for the above observables with option to change the produced meson mass
+        inline double probability_distribution(double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return probability_distribution(s, t);
+        };
+
+        inline double differential_xsection(double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return differential_xsection(s, t);
+        };
+
+        inline double integrated_xsection(double M2, double s)
+        {
+            kinematics->set_mX2(M2);
+            return integrated_xsection(s);
+        };
+
+        inline std::complex<double> SDME(int alpha, int lam, int lamp, double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return SDME(alpha, lam, lamp, s, t);
+        };
+
+        inline double beam_asymmetry_y(double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return beam_asymmetry_y(s, t);
+        };
+
+        inline double beam_asymmetry_4pi(double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return beam_asymmetry_4pi(s, t);
+        };
+
+        inline double parity_asymmetry(double M2, double s, double t)
+        {
+            kinematics->set_mX2(M2);
+            return parity_asymmetry(s, t);
+        };
     };
-  };
 };
 
 #endif

--- a/include/amplitudes/amplitude_sum.hpp
+++ b/include/amplitudes/amplitude_sum.hpp
@@ -54,7 +54,7 @@ namespace jpacPhoto
     // params to each sub amplitude
 
     // Evaluate the sum for given set of helicites, energy, and cos
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
   };
 };
 

--- a/include/amplitudes/amplitude_sum.hpp
+++ b/include/amplitudes/amplitude_sum.hpp
@@ -27,12 +27,12 @@ namespace jpacPhoto
   public:
     // Empty constructor
     amplitude_sum(reaction_kinematics * xkinem, std::string identifer = "")
-    : amplitude(xkinem, identifer, 0)
+    : amplitude(xkinem, identifer)
     {};
 
     // Constructor with a vector already set up
     amplitude_sum(reaction_kinematics * xkinem, std::vector<amplitude*> vec, std::string identifer = "")
-    : amplitude(xkinem, identifer, 0), amps(vec)
+    : amplitude(xkinem, identifer), amps(vec)
     {};
 
     // Add a new amplitude to the vector

--- a/include/amplitudes/amplitude_sum.hpp
+++ b/include/amplitudes/amplitude_sum.hpp
@@ -26,12 +26,12 @@ namespace jpacPhoto
 
   public:
     // Empty constructor
-    amplitude_sum(reaction_kinematics * xkinem, std::string identifer = "")
+    amplitude_sum(reaction_kinematics * xkinem, std::string identifer = "amplitude_sum")
     : amplitude(xkinem, identifer)
     {};
 
     // Constructor with a vector already set up
-    amplitude_sum(reaction_kinematics * xkinem, std::vector<amplitude*> vec, std::string identifer = "")
+    amplitude_sum(reaction_kinematics * xkinem, std::vector<amplitude*> vec, std::string identifer = "amplitude_sum")
     : amplitude(xkinem, identifer), amps(vec)
     {};
 
@@ -48,6 +48,12 @@ namespace jpacPhoto
       {
         amps.push_back(new_sum.amps[i]);
       }
+    };
+
+    // empty allowedJP, leave the checks to the individual amps instead
+    inline std::vector<std::array<int,2>> allowedJP()
+    {
+        return {};
     };
 
     // TODO: Add a set_params which timesi in one vector and allocates approriaten number of

--- a/include/amplitudes/baryon_resonance.hpp
+++ b/include/amplitudes/baryon_resonance.hpp
@@ -22,83 +22,83 @@
 
 namespace jpacPhoto
 {
-  class baryon_resonance : public amplitude
-  {
-  public:
-    // Constructor
-    baryon_resonance(reaction_kinematics * xkinem, int j, int p, double mass, double width, std::string name = "")
-    : amplitude(xkinem, name), mRes(mass), gamRes(width), J(j), P(p),
-      naturality(p * pow(-1, (j-1)/2))
+    class baryon_resonance : public amplitude
     {
-      set_nParams(2);
+        public:
+        // Constructor
+        baryon_resonance(reaction_kinematics * xkinem, int j, int p, double mass, double width, std::string name = "baryon_resonance")
+        : amplitude(xkinem, name),
+          mRes(mass), gamRes(width), 
+          J(j), P(p), naturality(p * pow(-1, (j-1)/2))
+        {
+            set_nParams(2);
+            add_allowedJP({1, -1}); // only allow vector (jpsi) for now
+            // TODO: remove explicit dependence on mJpsi
 
-      // save momentum and other J^P dependent quantities
-      pi_bar = real(kinematics->initial->momentum(mass * mass));
-      pf_bar = real(kinematics->final->momentum(mass * mass));
+            // save momentum and other J^P dependent quantities
+            pi_bar = real(kinematics->initial->momentum(mass * mass));
+            pf_bar = real(kinematics->final->momentum(mass * mass));
 
-      switch (J)
-      {
-        case 3:
+            if (abs(P) != 1)
+            {
+                std::cout << "Invalid parity " << P << " passed to " << name << ". Quitting...\n";
+                exit(0);
+            };
+            switch (P * J)
+            {
+                case  1: {l_min = 0; P_t = 2./3.; break;}
+                case -1: {l_min = 1; P_t = 3./5.; break;}
+                case  3: {l_min = 1; P_t = 3./5.; break;}
+                case -3: {l_min = 0; P_t = 2./3.; break;}
+                case  5: {l_min = 1; P_t = 3./5.; break;}
+                case -5: {l_min = 2; P_t = 1./3.; break;}
+            
+                default:
+                {
+                std::cout << "\nbaryon_resonance: spin-parity combination for J = " << J << "/2 and P = " << P << " not available. ";
+                std::cout << "Quiting... \n";
+                exit(0);
+                }
+            };
+        };
+
+        // Setting utility
+        void set_params(std::vector<double> params)
         {
-          if (P == -1)
-            {l_min = 0; P_t = 2./3.;}
-          else if (P == 1)
-            {l_min = 1; P_t = 3./5.;}
-          break;
-        }
-        case 5:
-        {
-          if (P == 1)
-            {l_min = 1; P_t = 3./5.;}
-          else if (P == -1)
-            {l_min = 2; P_t = 1./3.;}
-          break;
-        }
-        default:
-        {
-          std::cout << "\nbaryon_resonance: spin-parity combination for J = " << J << "/2 and P = " << P << " not available. ";
-          std::cout << "Quiting... \n";
-          exit(0);
-        }
-      }
+            check_nParams(params);
+            xBR = params[0];
+            R_photo = params[1];
+        };
+
+        // Combined total amplitude including Breit Wigner pole
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
+
+        // Photoexcitation helicity amplitude for the process gamma p -> R
+        std::complex<double> photo_coupling(int lam_i);
+
+        // Hadronic decay helicity amplitude for the R -> J/psi p process
+        std::complex<double> hadronic_coupling(int lam_f);
+
+        // Ad-hoc threshold factor to kill the resonance at threshold
+        double threshold_factor(double beta);
+
+
+        private:
+        int J, P, naturality; // (2xSpin) and parity of the resonance
+        double mRes, gamRes; // Resonant mass and width
+
+        int l_min; // lowest allowed relative angular momentum
+        double P_t; // Combinatorial factor due to only transverse polarized J/psi contribute
+
+        // Couplings
+        double xBR; // Hadronic banching fraction to j/psi p
+        double R_photo; // Photocoupling ratio
+
+        // Initial and final CoM momenta evaluated at resonance energy.
+        double pi_bar, pf_bar;
+
+        // saved energies and angle
+        double s, t, theta;
     };
-
-    // Setting utility
-    void set_params(std::vector<double> params)
-    {
-      check_nParams(params);
-      xBR = params[0];
-      R_photo = params[1];
-    };
-
-    // Photoexcitation helicity amplitude for the process gamma p -> R
-    std::complex<double> photo_coupling(int lam_i);
-
-    // Hadronic decay helicity amplitude for the R -> J/psi p process
-    std::complex<double> hadronic_coupling(int lam_f);
-
-    // Ad-hoc threshold factor to kill the resonance at threshold
-    double threshold_factor(double beta);
-
-    // Combined total amplitude including Breit Wigner pole
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
-
-    private:
-    int J, P, naturality; // (2xSpin) and parity of the resonance
-    double mRes, gamRes; // Resonant mass and width
-
-    int l_min; // lowest allowed relative angular momentum
-    double P_t; // Combinatorial factor due to only transverse polarized J/psi contribute
-
-    // Couplings
-    double xBR; // Hadronic banching fraction to j/psi p
-    double R_photo; // Photocoupling ratio
-
-    // Initial and final CoM momenta evaluated at resonance energy.
-    double pi_bar, pf_bar;
-
-    // saved energies and angle
-    double s, t, theta;
-  };
 };
 #endif

--- a/include/amplitudes/baryon_resonance.hpp
+++ b/include/amplitudes/baryon_resonance.hpp
@@ -24,27 +24,10 @@ namespace jpacPhoto
 {
   class baryon_resonance : public amplitude
   {
-  private:
-    int J, P, naturality; // (2xSpin) and parity of the resonance
-    double mRes, gamRes; // Resonant mass and width
-
-    int l_min; // lowest allowed relative angular momentum
-    double P_t; // Combinatorial factor due to only transverse polarized J/psi contribute
-
-    // Couplings
-    double xBR; // Hadronic banching fraction to j/psi p
-    double R_photo; // Photocoupling ratio
-
-    // Initial and final CoM momenta evaluated at resonance energy.
-    double pi_bar, pf_bar;
-
-    // saved energies and angle
-    double s, t, theta;
-
   public:
     // Constructor
     baryon_resonance(reaction_kinematics * xkinem, int j, int p, double mass, double width, std::string name = "")
-    : amplitude(xkinem, name, 2), mRes(mass), gamRes(width), J(j), P(p),
+    : amplitude(xkinem, name), mRes(mass), gamRes(width), J(j), P(p),
       naturality(p * pow(-1, (j-1)/2))
     {
       pi_bar = real(kinematics->initial->momentum(mass * mass));
@@ -96,6 +79,26 @@ namespace jpacPhoto
 
     // Combined total amplitude including Breit Wigner pole
     std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+
+      private:
+    // Set amplitude class options
+    int Nparams = 2; // Number of couplings
+
+    int J, P, naturality; // (2xSpin) and parity of the resonance
+    double mRes, gamRes; // Resonant mass and width
+
+    int l_min; // lowest allowed relative angular momentum
+    double P_t; // Combinatorial factor due to only transverse polarized J/psi contribute
+
+    // Couplings
+    double xBR; // Hadronic banching fraction to j/psi p
+    double R_photo; // Photocoupling ratio
+
+    // Initial and final CoM momenta evaluated at resonance energy.
+    double pi_bar, pf_bar;
+
+    // saved energies and angle
+    double s, t, theta;
   };
 };
 #endif

--- a/include/amplitudes/baryon_resonance.hpp
+++ b/include/amplitudes/baryon_resonance.hpp
@@ -32,8 +32,7 @@ namespace jpacPhoto
           J(j), P(p), naturality(p * pow(-1, (j-1)/2))
         {
             set_nParams(2);
-            add_allowedJP({1, -1}); // only allow vector (jpsi) for now
-            // TODO: remove explicit dependence on mJpsi
+            check_JP(xkinem->JP);
 
             // save momentum and other J^P dependent quantities
             pi_bar = real(kinematics->initial->momentum(mass * mass));
@@ -73,6 +72,14 @@ namespace jpacPhoto
         // Combined total amplitude including Breit Wigner pole
         std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
+        // only vector kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, -1}};
+        };
+
+        private:
+
         // Photoexcitation helicity amplitude for the process gamma p -> R
         std::complex<double> photo_coupling(int lam_i);
 
@@ -82,8 +89,6 @@ namespace jpacPhoto
         // Ad-hoc threshold factor to kill the resonance at threshold
         double threshold_factor(double beta);
 
-
-        private:
         int J, P, naturality; // (2xSpin) and parity of the resonance
         double mRes, gamRes; // Resonant mass and width
 

--- a/include/amplitudes/baryon_resonance.hpp
+++ b/include/amplitudes/baryon_resonance.hpp
@@ -30,6 +30,9 @@ namespace jpacPhoto
     : amplitude(xkinem, name), mRes(mass), gamRes(width), J(j), P(p),
       naturality(p * pow(-1, (j-1)/2))
     {
+      set_nParams(2);
+
+      // save momentum and other J^P dependent quantities
       pi_bar = real(kinematics->initial->momentum(mass * mass));
       pf_bar = real(kinematics->final->momentum(mass * mass));
 
@@ -63,7 +66,7 @@ namespace jpacPhoto
     // Setting utility
     void set_params(std::vector<double> params)
     {
-      check_Nparams(params);
+      check_nParams(params);
       xBR = params[0];
       R_photo = params[1];
     };
@@ -78,12 +81,9 @@ namespace jpacPhoto
     double threshold_factor(double beta);
 
     // Combined total amplitude including Breit Wigner pole
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
-      private:
-    // Set amplitude class options
-    int Nparams = 2; // Number of couplings
-
+    private:
     int J, P, naturality; // (2xSpin) and parity of the resonance
     double mRes, gamRes; // Resonant mass and width
 

--- a/include/amplitudes/dirac_exchange.hpp
+++ b/include/amplitudes/dirac_exchange.hpp
@@ -24,12 +24,12 @@ namespace jpacPhoto
         public:
         
         // constructor
-        dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
+        dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "dirac_exchange")
         : amplitude(xkinem, name),
             mEx(mass), mEx2(mass*mass)
         {
             set_nParams(2);
-            add_allowedJP({1, -1});
+            check_JP(xkinem->JP);
         };
 
         // Setting utility
@@ -53,6 +53,12 @@ namespace jpacPhoto
             case 1: ScBOT = true; break;
             }
         }
+
+        // only vector kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, -1}};
+        };
 
         protected:
 

--- a/include/amplitudes/dirac_exchange.hpp
+++ b/include/amplitudes/dirac_exchange.hpp
@@ -19,69 +19,72 @@
 
 namespace jpacPhoto
 {
-  class dirac_exchange : public amplitude
-  {
-  public:
-    // constructor
-    dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
-    : amplitude(xkinem, name),
-      mEx(mass), mEx2(mass*mass)
+    class dirac_exchange : public amplitude
     {
-      set_nParams(2);
+        public:
+        
+        // constructor
+        dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
+        : amplitude(xkinem, name),
+            mEx(mass), mEx2(mass*mass)
+        {
+            set_nParams(2);
+            add_allowedJP({1, -1});
+        };
+
+        // Setting utility
+        void set_params(std::vector<double> params)
+        {
+            check_nParams(params);
+            gGam = params[0];
+            gVec = params[1];
+        };
+
+        // Assemble the helicity amplitude by contracting the spinor indices
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
+
+        // debugging options to make either the photon or vector into scalars
+        void set_debug(int i)
+        {
+            switch (i)
+            {
+            case 3: ScTOP = true; ScBOT = true; break;
+            case 2: ScTOP = true; break;
+            case 1: ScBOT = true; break;
+            }
+        }
+
+        protected:
+
+        // DEBUGGING PARAMS
+        bool ScTOP = false, ScBOT = false;
+
+        // Exchange nucleon mass
+        double mEx, mEx2;
+
+        // couplings
+        double gGam = 0., gVec = 0.;
+
+        // Should be exactly u_man(s, zs);
+        double exchange_mass();
+
+        // Four-momentum of the exhange (u - channel)
+        std::complex<double> exchange_momentum(int mu);
+
+        // Slashed momentumn
+        std::complex<double> slashed_exchange_momentum(int i, int j);
+
+        // Slashed polarization vectors
+        std::complex<double> slashed_eps(int i, int j, double lam, polarization_vector * eps, bool STARRED, double s, double theta);
+
+        // Photon - excNucleon - recNucleon vertex
+        std::complex<double> top_vertex(int i, int lam_gam, int lam_rec);
+
+        // excNucleon - recNucleon - Vector vertex
+        std::complex<double> bottom_vertex(int j, int lam_vec, int lam_targ);
+
+        // Spin-1/2 propagator
+        std::complex<double> dirac_propagator(int i, int j);
     };
-
-    // Setting utility
-    void set_params(std::vector<double> params)
-    {
-      check_nParams(params);
-      gGam = params[0];
-      gVec = params[1];
-    };
-
-    // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
-
-    // debugging options to make either the photon or vector into scalars
-    void set_debug(int i)
-    {
-      switch (i)
-      {
-        case 3: ScTOP = true; ScBOT = true; break;
-        case 2: ScTOP = true; break;
-        case 1: ScBOT = true; break;
-      }
-    }
-
-  protected:
-    // DEBUGGING PARAMS
-    bool ScTOP = false, ScBOT = false;
-
-    // Exchange nucleon mass
-    double mEx, mEx2;
-
-    // couplings
-    double gGam = 0., gVec = 0.;
-
-    // Should be exactly u_man(s, zs);
-    double exchange_mass();
-
-    // Four-momentum of the exhange (u - channel)
-    std::complex<double> exchange_momentum(int mu);
-
-    // Slashed momentumn
-    std::complex<double> slashed_exchange_momentum(int i, int j);
-
-    // Slashed polarization vectors
-    std::complex<double> slashed_eps(int i, int j, double lam, polarization_vector * eps, bool STARRED, double s, double theta);
-
-    // Photon - excNucleon - recNucleon vertex
-    std::complex<double> top_vertex(int i, int lam_gam, int lam_rec);
-
-    // excNucleon - recNucleon - Vector vertex
-    std::complex<double> bottom_vertex(int j, int lam_vec, int lam_targ);
-
-    // Spin-1/2 propagator
-    std::complex<double> dirac_propagator(int i, int j);
-  };
 };
 #endif

--- a/include/amplitudes/dirac_exchange.hpp
+++ b/include/amplitudes/dirac_exchange.hpp
@@ -26,18 +26,20 @@ namespace jpacPhoto
     dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
     : amplitude(xkinem, name),
       mEx(mass), mEx2(mass*mass)
-    {};
+    {
+      set_nParams(2);
+    };
 
     // Setting utility
     void set_params(std::vector<double> params)
     {
-      check_Nparams(params);
+      check_nParams(params);
       gGam = params[0];
       gVec = params[1];
     };
 
     // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
     // debugging options to make either the photon or vector into scalars
     void set_debug(int i)
@@ -51,9 +53,6 @@ namespace jpacPhoto
     }
 
   protected:
-    // Set amplitude class options
-    int Nparams = 2; // Number of couplings
-
     // DEBUGGING PARAMS
     bool ScTOP = false, ScBOT = false;
 

--- a/include/amplitudes/dirac_exchange.hpp
+++ b/include/amplitudes/dirac_exchange.hpp
@@ -40,11 +40,18 @@ namespace jpacPhoto
             gVec = params[1];
         };
 
+        // Whether or not to include an exponential form factor (default false)
+        inline void set_formfactor(int FF, double bb = 0.)
+        {
+            IF_FF = FF;
+            cutoff = bb;
+        }
+
         // Assemble the helicity amplitude by contracting the spinor indices
         std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
         // debugging options to make either the photon or vector into scalars
-        void set_debug(int i)
+        inline void set_debug(int i)
         {
             switch (i)
             {
@@ -54,10 +61,10 @@ namespace jpacPhoto
             }
         }
 
-        // only vector kinematics allowed
+        // only vector and psuedo-scalar kinematics
         inline std::vector<std::array<int,2>> allowedJP()
         {
-            return {{1, -1}};
+            return {{1, -1}, {0, -1}};
         };
 
         protected:
@@ -66,7 +73,13 @@ namespace jpacPhoto
         bool ScTOP = false, ScBOT = false;
 
         // Exchange nucleon mass
+        double u;
         double mEx, mEx2;
+
+        // Form factor parameters
+        int IF_FF = 0;
+        double cutoff = 0.;
+        double form_factor();
 
         // couplings
         double gGam = 0., gVec = 0.;

--- a/include/amplitudes/dirac_exchange.hpp
+++ b/include/amplitudes/dirac_exchange.hpp
@@ -24,7 +24,7 @@ namespace jpacPhoto
   public:
     // constructor
     dirac_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
-    : amplitude(xkinem, name, 2),
+    : amplitude(xkinem, name),
       mEx(mass), mEx2(mass*mass)
     {};
 
@@ -51,6 +51,9 @@ namespace jpacPhoto
     }
 
   protected:
+    // Set amplitude class options
+    int Nparams = 2; // Number of couplings
+
     // DEBUGGING PARAMS
     bool ScTOP = false, ScBOT = false;
 

--- a/include/amplitudes/pomeron_exchange.hpp
+++ b/include/amplitudes/pomeron_exchange.hpp
@@ -33,22 +33,22 @@ namespace jpacPhoto
     // Optional OLDMODEL if true will default to helicity conserving amplitude
     pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, bool OLDMODEL = false, std::string name = "")
     : amplitude(xkinem, name), pomeron_traj(alpha), DELTA(OLDMODEL)
-    {};
+    {
+      set_nParams(2);
+    };
 
     // Setting utility
     void set_params(std::vector<double> params)
     {
-      check_Nparams(params);
+      check_nParams(params);
       norm = params[0];
       b0 = params[1];
     };
 
     // Assemble the helicity amplitude by contracting the lorentz indices
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
   private:
-    // Set amplitude class options
-    int Nparams = 2; // Number of couplings
 
     bool DELTA = false; // Whether or not to use the helicity conserving model 
     double norm = 0., b0 = 0.; // Regge factor parameters: normalization and t-slope

--- a/include/amplitudes/pomeron_exchange.hpp
+++ b/include/amplitudes/pomeron_exchange.hpp
@@ -32,7 +32,7 @@ namespace jpacPhoto
     // need a pointer to kinematic object, pointer to trajectory.
     // Optional OLDMODEL if true will default to helicity conserving amplitude
     pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, bool OLDMODEL = false, std::string name = "")
-    : amplitude(xkinem, name, 2), pomeron_traj(alpha), DELTA(OLDMODEL)
+    : amplitude(xkinem, name), pomeron_traj(alpha), DELTA(OLDMODEL)
     {};
 
     // Setting utility
@@ -47,6 +47,8 @@ namespace jpacPhoto
     std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
 
   private:
+    // Set amplitude class options
+    int Nparams = 2; // Number of couplings
 
     bool DELTA = false; // Whether or not to use the helicity conserving model 
     double norm = 0., b0 = 0.; // Regge factor parameters: normalization and t-slope

--- a/include/amplitudes/pomeron_exchange.hpp
+++ b/include/amplitudes/pomeron_exchange.hpp
@@ -4,6 +4,11 @@
 // Affiliation:  Joint Physics Analysis Center (JPAC)
 // Email:        dwinney@iu.edu
 // ---------------------------------------------------------------------------
+// REFERENCES:
+// [1] 1907.09393
+// [2] 1606.08912
+// [3] 1904.11706
+// ---------------------------------------------------------------------------
 
 #ifndef _POMERON_
 #define _POMERON_
@@ -31,8 +36,8 @@ namespace jpacPhoto
         // Constructor
         // need a pointer to kinematic object, pointer to trajectory.
         // Optional OLDMODEL if true will default to helicity conserving amplitude
-        pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, bool OLDMODEL = false, std::string name = "pomeron_exchange")
-        : amplitude(xkinem, name), pomeron_traj(alpha), DELTA(OLDMODEL)
+        pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, int model_ = 0, std::string name = "pomeron_exchange")
+        : amplitude(xkinem, name), pomeron_traj(alpha), model(model_)
         {
             set_nParams(2);
             check_JP(xkinem->JP);
@@ -56,8 +61,13 @@ namespace jpacPhoto
         };
 
         private:
+        
+        // Which model to use. 
+        int model = 0; 
+        // 0 - model in [1] Lesniak-Szcepaniak
+        // 1 - model in [2] Helicity conserving
+        // 2 - model in [3]
 
-        bool DELTA = false; // Whether or not to use the helicity conserving model 
         double norm = 0., b0 = 0.; // Regge factor parameters: normalization and t-slope
         regge_trajectory * pomeron_traj;
 

--- a/include/amplitudes/pomeron_exchange.hpp
+++ b/include/amplitudes/pomeron_exchange.hpp
@@ -1,6 +1,6 @@
 // Vector meson photoproduction dynamics proceeding through a pomeron exchange
 //
-// Author:       Daniel Winney (2019)
+// Author:       Daniel Winney (2020)
 // Affiliation:  Joint Physics Analysis Center (JPAC)
 // Email:        dwinney@iu.edu
 // ---------------------------------------------------------------------------
@@ -24,45 +24,52 @@
 
 namespace jpacPhoto
 {
-  class pomeron_exchange : public amplitude
-  {
-  public:
-
-    // Constructor
-    // need a pointer to kinematic object, pointer to trajectory.
-    // Optional OLDMODEL if true will default to helicity conserving amplitude
-    pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, bool OLDMODEL = false, std::string name = "")
-    : amplitude(xkinem, name), pomeron_traj(alpha), DELTA(OLDMODEL)
+    class pomeron_exchange : public amplitude
     {
-      set_nParams(2);
+        public:
+
+        // Constructor
+        // need a pointer to kinematic object, pointer to trajectory.
+        // Optional OLDMODEL if true will default to helicity conserving amplitude
+        pomeron_exchange(reaction_kinematics * xkinem, regge_trajectory * alpha, bool OLDMODEL = false, std::string name = "pomeron_exchange")
+        : amplitude(xkinem, name), pomeron_traj(alpha), DELTA(OLDMODEL)
+        {
+            set_nParams(2);
+            check_JP(xkinem->JP);
+        };
+
+        // Setting utility
+        void set_params(std::vector<double> params)
+        {
+            check_nParams(params);
+            norm = params[0];
+            b0 = params[1];
+        };
+
+        // Assemble the helicity amplitude by contracting the lorentz indices
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
+
+        // only vector kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, -1}};
+        };
+
+        private:
+
+        bool DELTA = false; // Whether or not to use the helicity conserving model 
+        double norm = 0., b0 = 0.; // Regge factor parameters: normalization and t-slope
+        regge_trajectory * pomeron_traj;
+
+        // Photon - Vector - Pomeron vertex
+        std::complex<double> top_vertex(int mu, int lam_gam, int lam_vec);
+
+        // Nucleon - Nucleon - Pomeron vertex
+        std::complex<double> bottom_vertex(int mu, int lam_targ, int lam_rec);
+
+        // Energy dependence from Pomeron propogator
+        std::complex<double> regge_factor();
     };
-
-    // Setting utility
-    void set_params(std::vector<double> params)
-    {
-      check_nParams(params);
-      norm = params[0];
-      b0 = params[1];
-    };
-
-    // Assemble the helicity amplitude by contracting the lorentz indices
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
-
-  private:
-
-    bool DELTA = false; // Whether or not to use the helicity conserving model 
-    double norm = 0., b0 = 0.; // Regge factor parameters: normalization and t-slope
-    regge_trajectory * pomeron_traj;
-
-    // Photon - Vector - Pomeron vertex
-    std::complex<double> top_vertex(int mu, int lam_gam, int lam_vec);
-
-    // Nucleon - Nucleon - Pomeron vertex
-    std::complex<double> bottom_vertex(int mu, int lam_targ, int lam_rec);
-
-    // Energy dependence from Pomeron propogator
-    std::complex<double> regge_factor();
-  };
 };
 
 #endif

--- a/include/amplitudes/primakoff_effect.hpp
+++ b/include/amplitudes/primakoff_effect.hpp
@@ -90,9 +90,9 @@ namespace jpacPhoto
         };
 
         // Kinematic quantities   
-        long double mX2 = kinematics->mX2;
-        long double mA2 = kinematics->mBar2;
-        long double Q2  = kinematics->Q2;
+        long double mX2 =  kinematics->mX2;
+        long double mA2 =  kinematics->mT2;
+        long double Q2  = -kinematics->mB2;
 
         long double cX, sX2;
         long double pGam, pX;

--- a/include/amplitudes/primakoff_effect.hpp
+++ b/include/amplitudes/primakoff_effect.hpp
@@ -18,7 +18,7 @@ namespace jpacPhoto
         public:
         // Constructor 
         primakoff_effect(reaction_kinematics * xkinem, std::string amp_id = "")
-        : amplitude(xkinem, amp_id, 4)
+        : amplitude(xkinem, amp_id)
         {};
 
         void set_params(std::vector<double> params)
@@ -55,6 +55,8 @@ namespace jpacPhoto
         double integrated_xsection(double s);
 
         private:
+        // Set amplitude class options
+        int Nparams = 4; // Number of couplings
 
         // Parameters
         int    LT    = 0 ;  // longitudinal (0) or transverse (1) photon
@@ -81,7 +83,7 @@ namespace jpacPhoto
         };
 
         // Kinematic quantities   
-        long double mX2 = kinematics->mVec2;
+        long double mX2 = kinematics->mX2;
         long double mA2 = kinematics->mBar2;
         long double Q2  = kinematics->Q2;
 

--- a/include/amplitudes/primakoff_effect.hpp
+++ b/include/amplitudes/primakoff_effect.hpp
@@ -19,11 +19,13 @@ namespace jpacPhoto
         // Constructor 
         primakoff_effect(reaction_kinematics * xkinem, std::string amp_id = "")
         : amplitude(xkinem, amp_id)
-        {};
+        {
+            set_nParams(4);
+        };
 
         void set_params(std::vector<double> params)
         {
-            check_Nparams(params); 
+            check_nParams(params); 
             Z = params[0];
             R = params[1];
             a = params[2];
@@ -44,7 +46,7 @@ namespace jpacPhoto
         };
 
         // individual helicity amplitudes not supported but need to provide definition for virtual class.
-        inline std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t)
+        inline std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t)
         {
             std::cout << "Warning! Individual helicity amplitudes not supported by primakoff_effect!\n";
             return 0.;
@@ -55,8 +57,6 @@ namespace jpacPhoto
         double integrated_xsection(double s);
 
         private:
-        // Set amplitude class options
-        int Nparams = 4; // Number of couplings
 
         // Parameters
         int    LT    = 0 ;  // longitudinal (0) or transverse (1) photon

--- a/include/amplitudes/primakoff_effect.hpp
+++ b/include/amplitudes/primakoff_effect.hpp
@@ -17,10 +17,11 @@ namespace jpacPhoto
     {
         public:
         // Constructor 
-        primakoff_effect(reaction_kinematics * xkinem, std::string amp_id = "")
+        primakoff_effect(reaction_kinematics * xkinem, std::string amp_id = "primakoff_effect")
         : amplitude(xkinem, amp_id)
         {
             set_nParams(4);
+            check_JP(xkinem->JP);
         };
 
         void set_params(std::vector<double> params)
@@ -55,6 +56,12 @@ namespace jpacPhoto
         // instead we override the definition of differential_xsection in amplitude.hpp
         double differential_xsection(double s, double t);
         double integrated_xsection(double s);
+
+        // only axial-vector kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, 1}};
+        };
 
         private:
 

--- a/include/amplitudes/pseudoscalar_exchange.hpp
+++ b/include/amplitudes/pseudoscalar_exchange.hpp
@@ -32,73 +32,81 @@
 
 namespace jpacPhoto
 {
-  class pseudoscalar_exchange : public amplitude
-  {
-  public:
-    // constructor for fixed meson exchange
-    pseudoscalar_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
-    : amplitude(xkinem, name), mEx2(mass*mass), REGGE(false)
+    class pseudoscalar_exchange : public amplitude
     {
-        set_nParams(2);
+        public:
+        // constructor for fixed meson exchange
+        pseudoscalar_exchange(reaction_kinematics * xkinem, double mass, std::string name = "pseudoscalar_exchange")
+        : amplitude(xkinem, name), mEx2(mass*mass), REGGE(false)
+        {
+            set_nParams(2);
+            check_JP(xkinem->JP);
+        };
+
+        // constructors for regge exchange
+        pseudoscalar_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string name = "pseudoscalar_exchange")
+        : amplitude(xkinem, name), alpha(traj), REGGE(true)
+        {
+            set_nParams(2);
+            check_JP(xkinem->JP);
+        };
+
+        // Setting utility
+        void set_params(std::vector<double> params)
+        {
+            check_nParams(params);
+            gGamma = params[0];
+            gNN = params[1];
+        };
+
+        // Whether or not to include an exponential form factor (default false)
+        void set_formfactor(bool FF, double bb = 0.)
+        {
+            IF_FF = FF;
+            b = bb;
+        }
+
+        // Assemble the helicity amplitude by contracting the spinor indices
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
+
+        // only axial-vector kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, 1}};
+        };
+
+        private:
+
+        // Whether to use fixed-spin propagator (false) or regge (true)
+        bool REGGE;
+
+        // Mass of the exchanged pseudo-scalar (if REGGE = false)
+        // ignored otherwise
+        double mEx2;
+
+        // Regge trajectory for the pion (if REGGE = true)
+        // ignored otherwise
+        linear_trajectory * alpha;
+
+        // Coupling constants
+        double gGamma = 0.; // Gamma - Axial - Pseudoscalar coupling 
+        double gNN = 0.;    // Pseudoscalar - Nucleon coupling
+
+        bool IF_FF = false; // Whether to include the exponential form factor
+        double b = 0.; // "t-slope" parameter in the FF
+
+        // Whether to switch to using the feynman rules
+        bool FOUR_VECS = false; 
+
+        // Photon - pseudoscalar - Axial vertex
+        std::complex<double> top_vertex(double lam_gam, double lam_vec);
+
+        // Pseudoscalar - Nucleon vertex
+        std::complex<double> bottom_vertex(double lam_targ, double lam_rec);
+
+        // Simple pole propagator
+        std::complex<double> scalar_propagator();
     };
-
-    // constructors for regge exchange
-    pseudoscalar_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string name = "")
-    : amplitude(xkinem, name), alpha(traj), REGGE(true)
-    {
-        set_nParams(2);
-    };
-
-    // Setting utility
-    void set_params(std::vector<double> params)
-    {
-      check_nParams(params);
-      gGamma = params[0];
-      gNN = params[1];
-    };
-
-    // Whether or not to include an exponential form factor (default false)
-    void set_formfactor(bool FF, double bb = 0.)
-    {
-      IF_FF = FF;
-      b = bb;
-    }
-
-    // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
-
-  private:
-
-    // Whether to use fixed-spin propagator (false) or regge (true)
-    bool REGGE;
-
-    // Mass of the exchanged pseudo-scalar (if REGGE = false)
-    // ignored otherwise
-    double mEx2;
-
-    // Regge trajectory for the pion (if REGGE = true)
-    // ignored otherwise
-    linear_trajectory * alpha;
-
-    // Coupling constants
-    double gGamma = 0.; // Gamma - Axial - Pseudoscalar coupling 
-    double gNN = 0.;    // Pseudoscalar - Nucleon coupling
-
-    bool IF_FF = false; // Whether to include the exponential form factor
-    double b = 0.; // "t-slope" parameter in the FF
-
-    // Whether to switch to using the feynman rules
-    bool FOUR_VECS = false; 
-
-    // Photon - pseudoscalar - Axial vertex
-    std::complex<double> top_vertex(double lam_gam, double lam_vec);
-
-    // Pseudoscalar - Nucleon vertex
-    std::complex<double> bottom_vertex(double lam_targ, double lam_rec);
-
-    // Simple pole propagator
-    std::complex<double> scalar_propagator();
-  };
 };
 
 #endif

--- a/include/amplitudes/pseudoscalar_exchange.hpp
+++ b/include/amplitudes/pseudoscalar_exchange.hpp
@@ -37,12 +37,12 @@ namespace jpacPhoto
   public:
     // constructor for fixed meson exchange
     pseudoscalar_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
-    : amplitude(xkinem, name, 2), mEx2(mass*mass), REGGE(false)
+    : amplitude(xkinem, name), mEx2(mass*mass), REGGE(false)
     {};
 
     // constructors for regge exchange
     pseudoscalar_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string name = "")
-    : amplitude(xkinem, name, 2), alpha(traj), REGGE(true)
+    : amplitude(xkinem, name), alpha(traj), REGGE(true)
     {};
 
     // Setting utility
@@ -64,6 +64,8 @@ namespace jpacPhoto
     std::complex<double> helicity_amplitude(std::vector<int> helicities, double xs, double xt);
 
   private:
+    // Set amplitude class options
+    int Nparams = 2; // Number of couplings
 
     // Whether to use fixed-spin propagator (false) or regge (true)
     bool REGGE;

--- a/include/amplitudes/pseudoscalar_exchange.hpp
+++ b/include/amplitudes/pseudoscalar_exchange.hpp
@@ -38,17 +38,21 @@ namespace jpacPhoto
     // constructor for fixed meson exchange
     pseudoscalar_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
     : amplitude(xkinem, name), mEx2(mass*mass), REGGE(false)
-    {};
+    {
+        set_nParams(2);
+    };
 
     // constructors for regge exchange
     pseudoscalar_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string name = "")
     : amplitude(xkinem, name), alpha(traj), REGGE(true)
-    {};
+    {
+        set_nParams(2);
+    };
 
     // Setting utility
     void set_params(std::vector<double> params)
     {
-      check_Nparams(params);
+      check_nParams(params);
       gGamma = params[0];
       gNN = params[1];
     };
@@ -61,11 +65,9 @@ namespace jpacPhoto
     }
 
     // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double xs, double xt);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
 
   private:
-    // Set amplitude class options
-    int Nparams = 2; // Number of couplings
 
     // Whether to use fixed-spin propagator (false) or regge (true)
     bool REGGE;

--- a/include/amplitudes/rarita_exchange.hpp
+++ b/include/amplitudes/rarita_exchange.hpp
@@ -12,31 +12,32 @@
 
 namespace jpacPhoto
 {
-  class rarita_exchange : public dirac_exchange
-  {
-  public:
-    // Constructor
-    rarita_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
-    : dirac_exchange(xkinem, mass, name)
-    {};
+    class rarita_exchange : public dirac_exchange
+    {
+        public:
+        
+        // Constructor
+        rarita_exchange(reaction_kinematics * xkinem, double mass, std::string name = "")
+        : dirac_exchange(xkinem, mass, name)
+        {};
 
-    // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
+        // Assemble the helicity amplitude by contracting the spinor indices
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
 
-  protected:
+        protected:
 
-    // rank-2 traceless tensor
-    std::complex<double> g_bar(int mu, int nu);
+        // rank-2 traceless tensor
+        std::complex<double> g_bar(int mu, int nu);
 
-    // g_bar contracted with gamma^nu
-    std::complex<double> slashed_g_bar(int mu, int i, int j);
+        // g_bar contracted with gamma^nu
+        std::complex<double> slashed_g_bar(int mu, int i, int j);
 
-    // Relative momentum entering or exiting the propagator
-    std::complex<double> relative_momentum(int mu, std::string in_out);
+        // Relative momentum entering or exiting the propagator
+        std::complex<double> relative_momentum(int mu, std::string in_out);
 
-    // Spin-3/2 propagator
-    std::complex<double> rarita_propagator(int i, int j);
-  };
+        // Spin-3/2 propagator
+        std::complex<double> rarita_propagator(int i, int j);
+    };
 };
 
 #endif

--- a/include/amplitudes/rarita_exchange.hpp
+++ b/include/amplitudes/rarita_exchange.hpp
@@ -21,7 +21,7 @@ namespace jpacPhoto
     {};
 
     // Assemble the helicity amplitude by contracting the spinor indices
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double xs, double xt);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double xs, double xt);
 
   protected:
 

--- a/include/amplitudes/vector_exchange.hpp
+++ b/include/amplitudes/vector_exchange.hpp
@@ -66,10 +66,10 @@ namespace jpacPhoto
         };
 
         // Whether or not to include an exponential form factor (default false)
-        inline void set_formfactor(bool FF, double bb = 0.)
+        inline void set_formfactor(int FF, double bb = 0.)
         {
             IF_FF = FF;
-            b = bb;
+            cutoff = bb;
         }
 
         // Assemble the helicity amplitude by contracting the lorentz indices
@@ -78,7 +78,7 @@ namespace jpacPhoto
         // axial vector and scalar kinematics allowed
         inline std::vector<std::array<int,2>> allowedJP()
         {
-            return {{1, 1}, {0, 1}};
+            return {{1, 1}, {0, 1}, {0, -1}};
         };
 
         private:
@@ -93,8 +93,9 @@ namespace jpacPhoto
         bool FOUR_VEC = false;
 
         // Form factor parameters
-        bool IF_FF = false;
-        double b = 0.;
+        int IF_FF = 0;
+        double cutoff = 0.;
+        double form_factor();
 
         // Couplings to the axial-vector/photon and vector/tensor couplings to nucleon
         double gGam = 0., gpGam = 0., gV = 0., gT = 0.;
@@ -103,7 +104,7 @@ namespace jpacPhoto
         // Covariant evaluation
 
         // Mass of the exchange
-        double mEx2;
+        double mEx2 = 0.;
 
         // Full covariant amplitude
         std::complex<double> covariant_amplitude(std::array<int, 4> helicities);
@@ -116,6 +117,9 @@ namespace jpacPhoto
 
         // Nucleon - Nucleon - Vector vertex
         std::complex<double> bottom_vertex(int nu, int lam_targ, int lam_rec);
+
+        // Photon field strength tensor
+        std::complex<double> field_tensor(int mu, int nu, int lambda);
 
         // Vector propogator
         std::complex<double> vector_propagator(int mu, int nu);

--- a/include/amplitudes/vector_exchange.hpp
+++ b/include/amplitudes/vector_exchange.hpp
@@ -37,6 +37,9 @@ namespace jpacPhoto
         {
             set_nParams(3);
             check_JP(xkinem->JP);
+
+            // For scalar interaction only 4-vector eval implemented so far
+            if (xkinem->JP[0] == 0) FOUR_VEC = true;
         };
 
         // Constructor for the reggized)
@@ -45,6 +48,12 @@ namespace jpacPhoto
         {
             set_nParams(3);
             check_JP(xkinem->JP);
+
+            if (xkinem->JP[0] == 0)
+            {
+                std::cout << "Error! Scalar production via Reggeized vector_exchange not yet implemented...\n";
+                exit(0);
+            }
         };
 
         // Setting utility
@@ -62,13 +71,6 @@ namespace jpacPhoto
             IF_FF = FF;
             b = bb;
         }
-
-        // Special case of scalar photoproduction relevant for the X(6900)
-        inline void set_scalarX(bool X)
-        {
-            IF_SCALAR_X = X;
-            FOUR_VEC = true; // Currently scalar top vertex is not implemented in the faster analytic expression, need to do 4-vector algebra
-        };
 
         // Assemble the helicity amplitude by contracting the lorentz indices
         std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
@@ -93,9 +95,6 @@ namespace jpacPhoto
         // Form factor parameters
         bool IF_FF = false;
         double b = 0.;
-
-        // IF to treat the produced particle as a scalar
-        bool IF_SCALAR_X = false;
 
         // Couplings to the axial-vector/photon and vector/tensor couplings to nucleon
         double gGam = 0., gpGam = 0., gV = 0., gT = 0.;

--- a/include/amplitudes/vector_exchange.hpp
+++ b/include/amplitudes/vector_exchange.hpp
@@ -33,17 +33,21 @@ namespace jpacPhoto
     // Constructor for fixed spin
     vector_exchange(reaction_kinematics * xkinem, double mass, std::string id = "")
     : amplitude(xkinem, id), mEx2(mass*mass), REGGE(false)
-    {};
+    {
+        set_nParams(3);
+    };
 
     // Constructor for the reggized)
     vector_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string id = "")
     : amplitude(xkinem, id), alpha(traj), REGGE(true)
-    {};
+    {
+        set_nParams(3);
+    };
 
     // Setting utility
     inline void set_params(std::vector<double> params)
     {
-      check_Nparams(params); // make sure the right amout of params passed
+      check_nParams(params); // make sure the right amout of params passed
       gGam = params[0];
       gV = params[1];
       gT = params[2];
@@ -64,18 +68,14 @@ namespace jpacPhoto
     };
 
     // Assemble the helicity amplitude by contracting the lorentz indices
-    std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
+    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
 
   private:
-    // Set amplitude class options
-    int Nparams = 3; // Number of couplings
-
-    double zt;
-
     // if using reggeized propagator
     bool REGGE;
     // or the regge trajectory of the exchange
     linear_trajectory * alpha;
+    double zt;
 
     // Whether using analytic or covariant expression
     bool FOUR_VEC = false;
@@ -97,7 +97,7 @@ namespace jpacPhoto
     double mEx2;
 
     // Full covariant amplitude
-    std::complex<double> covariant_amplitude(std::vector<int> helicities);
+    std::complex<double> covariant_amplitude(std::array<int, 4> helicities);
     
     // Four-momentum of the exhange
     std::complex<double> exchange_momenta(int mu);

--- a/include/amplitudes/vector_exchange.hpp
+++ b/include/amplitudes/vector_exchange.hpp
@@ -27,108 +27,118 @@
 
 namespace jpacPhoto
 {
-  class vector_exchange : public amplitude
-  {
-  public:
-    // Constructor for fixed spin
-    vector_exchange(reaction_kinematics * xkinem, double mass, std::string id = "")
-    : amplitude(xkinem, id), mEx2(mass*mass), REGGE(false)
+    class vector_exchange : public amplitude
     {
-        set_nParams(3);
+        public:
+
+        // Constructor for fixed spin
+        vector_exchange(reaction_kinematics * xkinem, double mass, std::string id = "vector_exchange")
+        : amplitude(xkinem, id), mEx2(mass*mass), REGGE(false)
+        {
+            set_nParams(3);
+            check_JP(xkinem->JP);
+        };
+
+        // Constructor for the reggized)
+        vector_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string id = "vector_exchange")
+        : amplitude(xkinem, id), alpha(traj), REGGE(true)
+        {
+            set_nParams(3);
+            check_JP(xkinem->JP);
+        };
+
+        // Setting utility
+        inline void set_params(std::vector<double> params)
+        {
+            check_nParams(params); // make sure the right amout of params passed
+            gGam = params[0];
+            gV = params[1];
+            gT = params[2];
+        };
+
+        // Whether or not to include an exponential form factor (default false)
+        inline void set_formfactor(bool FF, double bb = 0.)
+        {
+            IF_FF = FF;
+            b = bb;
+        }
+
+        // Special case of scalar photoproduction relevant for the X(6900)
+        inline void set_scalarX(bool X)
+        {
+            IF_SCALAR_X = X;
+            FOUR_VEC = true; // Currently scalar top vertex is not implemented in the faster analytic expression, need to do 4-vector algebra
+        };
+
+        // Assemble the helicity amplitude by contracting the lorentz indices
+        std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
+
+        // axial vector and scalar kinematics allowed
+        inline std::vector<std::array<int,2>> allowedJP()
+        {
+            return {{1, 1}, {0, 1}};
+        };
+
+        private:
+
+        // if using reggeized propagator
+        bool REGGE;
+        // or the regge trajectory of the exchange
+        linear_trajectory * alpha;
+        double zt;
+
+        // Whether using analytic or covariant expression
+        bool FOUR_VEC = false;
+
+        // Form factor parameters
+        bool IF_FF = false;
+        double b = 0.;
+
+        // IF to treat the produced particle as a scalar
+        bool IF_SCALAR_X = false;
+
+        // Couplings to the axial-vector/photon and vector/tensor couplings to nucleon
+        double gGam = 0., gpGam = 0., gV = 0., gT = 0.;
+
+        // ---------------------------------------------------------------------------
+        // Covariant evaluation
+
+        // Mass of the exchange
+        double mEx2;
+
+        // Full covariant amplitude
+        std::complex<double> covariant_amplitude(std::array<int, 4> helicities);
+
+        // Four-momentum of the exhange
+        std::complex<double> exchange_momenta(int mu);
+
+        // Photon - Axial Vector - Vector vertex
+        std::complex<double> top_vertex(int mu, int lam_gam, int lam_vec);
+
+        // Nucleon - Nucleon - Vector vertex
+        std::complex<double> bottom_vertex(int nu, int lam_targ, int lam_rec);
+
+        // Vector propogator
+        std::complex<double> vector_propagator(int mu, int nu);
+
+        // ---------------------------------------------------------------------------
+        // Analytic evaluation
+
+        // Photon - Axial - Vector
+        std::complex<double> top_residue(int lam_gam, int lam_vec);
+
+        // Nucleon - Nucleon - Vector
+        std::complex<double> bottom_residue(int lam_targ, int lam_rec);
+
+        // Reggeon propagator
+        std::complex<double> regge_propagator(int j, int lam, int lamp);
+
+        // Half angle factors
+        std::complex<double> half_angle_factor(int lam, int lamp);
+
+        // Angular momentum barrier factor
+        std::complex<double> barrier_factor(int j, int M);
     };
-
-    // Constructor for the reggized)
-    vector_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string id = "")
-    : amplitude(xkinem, id), alpha(traj), REGGE(true)
-    {
-        set_nParams(3);
-    };
-
-    // Setting utility
-    inline void set_params(std::vector<double> params)
-    {
-      check_nParams(params); // make sure the right amout of params passed
-      gGam = params[0];
-      gV = params[1];
-      gT = params[2];
-    };
-
-    // Whether or not to include an exponential form factor (default false)
-    inline void set_formfactor(bool FF, double bb = 0.)
-    {
-      IF_FF = FF;
-      b = bb;
-    }
-
-    // Special case of scalar photoproduction relevant for the X(6900)
-    inline void set_scalarX(bool X)
-    {
-      IF_SCALAR_X = X;
-      FOUR_VEC = true; // Currently scalar top vertex is not implemented in the faster analytic expression, need to do 4-vector algebra
-    };
-
-    // Assemble the helicity amplitude by contracting the lorentz indices
-    std::complex<double> helicity_amplitude(std::array<int, 4> helicities, double s, double t);
-
-  private:
-    // if using reggeized propagator
-    bool REGGE;
-    // or the regge trajectory of the exchange
-    linear_trajectory * alpha;
-    double zt;
-
-    // Whether using analytic or covariant expression
-    bool FOUR_VEC = false;
-
-    // Form factor parameters
-    bool IF_FF = false;
-    double b = 0.;
-
-    // IF to treat the produced particle as a scalar
-    bool IF_SCALAR_X = false;
-
-    // Couplings to the axial-vector/photon and vector/tensor couplings to nucleon
-    double gGam = 0., gpGam = 0., gV = 0., gT = 0.;
-
-    // ---------------------------------------------------------------------------
-    // Covariant evaluation
-
-    // Mass of the exchange
-    double mEx2;
-
-    // Full covariant amplitude
-    std::complex<double> covariant_amplitude(std::array<int, 4> helicities);
-    
-    // Four-momentum of the exhange
-    std::complex<double> exchange_momenta(int mu);
-
-    // Photon - Axial Vector - Vector vertex
-    std::complex<double> top_vertex(int mu, int lam_gam, int lam_vec);
-
-    // Nucleon - Nucleon - Vector vertex
-    std::complex<double> bottom_vertex(int nu, int lam_targ, int lam_rec);
-
-    // Vector propogator
-    std::complex<double> vector_propagator(int mu, int nu);
-
-    // ---------------------------------------------------------------------------
-    // Analytic evaluation
-
-    // Photon - Axial - Vector
-    std::complex<double> top_residue(int lam_gam, int lam_vec);
-
-    // Nucleon - Nucleon - Vector
-    std::complex<double> bottom_residue(int lam_targ, int lam_rec);
-
-    // Reggeon propagator
-    std::complex<double> regge_propagator(int j, int lam, int lamp);
-
-    // Half angle factors
-    std::complex<double> half_angle_factor(int lam, int lamp);
-
-    // Angular momentum barrier factor
-    std::complex<double> barrier_factor(int j, int M);
-  };
 };
 
 #endif

--- a/include/amplitudes/vector_exchange.hpp
+++ b/include/amplitudes/vector_exchange.hpp
@@ -31,13 +31,13 @@ namespace jpacPhoto
   {
   public:
     // Constructor for fixed spin
-    vector_exchange(reaction_kinematics * xkinem, double mass, std::string exchange = "")
-    : amplitude(xkinem, exchange, 3), mEx2(mass*mass), REGGE(false)
+    vector_exchange(reaction_kinematics * xkinem, double mass, std::string id = "")
+    : amplitude(xkinem, id), mEx2(mass*mass), REGGE(false)
     {};
 
     // Constructor for the reggized)
-    vector_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string exchange = "")
-    : amplitude(xkinem, exchange, 3), alpha(traj), REGGE(true)
+    vector_exchange(reaction_kinematics * xkinem, linear_trajectory * traj, std::string id = "")
+    : amplitude(xkinem, id), alpha(traj), REGGE(true)
     {};
 
     // Setting utility
@@ -67,6 +67,8 @@ namespace jpacPhoto
     std::complex<double> helicity_amplitude(std::vector<int> helicities, double s, double t);
 
   private:
+    // Set amplitude class options
+    int Nparams = 3; // Number of couplings
 
     double zt;
 

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -57,24 +57,34 @@ namespace jpacPhoto
     const std::complex<double> xi(0., 1.);
     const std::complex<double> ieps(0., EPS);
 
-    // Masses in GeV
+    // Meson masses in GeV
     const double mPi        = 0.13957000;
     const double mK         = 0.49367700;
     const double mEta       = 0.54753;
     const double mRho       = 0.77526;
     const double mOmega     = 0.78265;
     const double mPhi       = 1.01956;
-    const double mPro       = 0.938272;
     const double mJpsi      = 3.0969160;
     const double mPsi2S     = 3.686;
+    const double mD         = 1.86965;
+    const double mDstar     = 2.01026;
     const double mUpsilon1S = 9.4603;
     const double mUpsilon2S = 10.02336;
     const double mUpsilon3S = 10.3552;
 
-    // Masses squared
+    // Meson masses squared
     const double mPi2       = mPi * mPi;
-    const double mPro2      = mPro * mPro;
     const double mJpsi2     = mJpsi * mJpsi;
+    const double mD2        = mD * mD;
+    const double mDstar2    = mDstar * mDstar; 
+
+    // Baryon masses
+    const double mPro       = 0.938272;
+    const double mLambdaC   = 2.28646;
+
+    // Baryon masses squared
+    const double mPro2      = mPro * mPro;
+    const double mLambdaC2   = mLambdaC * mLambdaC;
 
     // Decay constants in GeV
     const double fJpsi      = 0.278;

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -14,27 +14,27 @@
 
 namespace jpacPhoto
 {
-  // little function for printing to screen instead of having to copy this line all the time
-  template<typename T>
-  inline void debug(T x)
-  {
-    std::cout << x << std::endl;
-  };
+    // little function for printing to screen instead of having to copy this line all the time
+    template<typename T>
+    inline void debug(T x)
+    {
+        std::cout << x << std::endl;
+    };
 
-  template<typename T, typename F>
-  inline void debug(T x, F y)
-  {
-    std::cout << std::left << std::setw(15) << x;
-    std::cout << std::left << std::setw(15) << y << std::endl;
-  };
+    template<typename T, typename F>
+    inline void debug(T x, F y)
+    {
+        std::cout << std::left << std::setw(15) << x;
+        std::cout << std::left << std::setw(15) << y << std::endl;
+    };
 
-  template<typename T, typename F, typename G>
-  inline void debug(T x, F y, G z)
-  {
-    std::cout << std::left << std::setw(15) << x;
-    std::cout << std::left << std::setw(15) << y;
-    std::cout << std::left << std::setw(15) << z << std::endl;
-  };
+    template<typename T, typename F, typename G>
+    inline void debug(T x, F y, G z)
+    {
+        std::cout << std::left << std::setw(15) << x;
+        std::cout << std::left << std::setw(15) << y;
+        std::cout << std::left << std::setw(15) << z << std::endl;
+    };
 };
 
 #endif
@@ -47,52 +47,52 @@ namespace jpacPhoto
 
 namespace jpacPhoto
 {
-  // ---------------------------------------------------------------------------
-  const double deg2rad  = (M_PI / 180.);
-  const double EPS      = 1.e-6;
-  const double M_ALPHA  = 1. / 137.;
-  const double e        = sqrt(4. * M_PI * M_ALPHA);
+    // ---------------------------------------------------------------------------
+    const double deg2rad  = (M_PI / 180.);
+    const double EPS      = 1.e-6;
+    const double M_ALPHA  = 1. / 137.;
+    const double e        = sqrt(4. * M_PI * M_ALPHA);
 
-  const std::complex<double> xr(1., 0.);
-  const std::complex<double> xi(0., 1.);
-  const std::complex<double> ieps(0., EPS);
+    const std::complex<double> xr(1., 0.);
+    const std::complex<double> xi(0., 1.);
+    const std::complex<double> ieps(0., EPS);
 
-  // Masses in GeV
-  const double mPi        = 0.13957000;
-  const double mK         = 0.49367700;
-  const double mEta       = 0.54753;
-  const double mRho       = 0.77526;
-  const double mOmega     = 0.78265;
-  const double mPhi       = 1.01956;
-  const double mPro       = 0.938272;
-  const double mJpsi      = 3.0969160;
-  const double mPsi2S     = 3.686;
-  const double mUpsilon1S = 9.4603;
-  const double mUpsilon2S = 10.02336;
-  const double mUpsilon3S = 10.3552;
+    // Masses in GeV
+    const double mPi        = 0.13957000;
+    const double mK         = 0.49367700;
+    const double mEta       = 0.54753;
+    const double mRho       = 0.77526;
+    const double mOmega     = 0.78265;
+    const double mPhi       = 1.01956;
+    const double mPro       = 0.938272;
+    const double mJpsi      = 3.0969160;
+    const double mPsi2S     = 3.686;
+    const double mUpsilon1S = 9.4603;
+    const double mUpsilon2S = 10.02336;
+    const double mUpsilon3S = 10.3552;
 
-  // Masses squared
-  const double mPi2       = mPi * mPi;
-  const double mPro2      = mPro * mPro;
-  const double mJpsi2     = mJpsi * mJpsi;
+    // Masses squared
+    const double mPi2       = mPi * mPi;
+    const double mPro2      = mPro * mPro;
+    const double mJpsi2     = mJpsi * mJpsi;
 
-  // Decay constants in GeV
-  const double fJpsi      = 0.278;
-  const double fUpsilon1S = 0.23345;
-  const double fUpsilon2S = 0.16563;
-  const double fUpsilon3S = 0.1431;
+    // Decay constants in GeV
+    const double fJpsi      = 0.278;
+    const double fUpsilon1S = 0.23345;
+    const double fUpsilon2S = 0.16563;
+    const double fUpsilon3S = 0.1431;
 
-  // Photon lab energy
-  inline double E_beam(double W)
-  {
-    return (W*W / mPro - mPro) / 2.;
-  };
-  
-  // Center of mass energy given beam energy
-  inline double W_cm(double egam)
-  {
-    return sqrt(mPro * (2. * egam + mPro));
-  };
+    // Photon lab energy
+    inline double E_beam(double W)
+    {
+        return (W*W / mPro - mPro) / 2.;
+    };
+
+    // Center of mass energy given beam energy
+    inline double W_cm(double egam)
+    {
+        return sqrt(mPro * (2. * egam + mPro));
+    };
 
 };
 // ---------------------------------------------------------------------------

--- a/include/dirac_spinor.hpp
+++ b/include/dirac_spinor.hpp
@@ -25,34 +25,36 @@
 
 namespace jpacPhoto
 {
-  class dirac_spinor
-  {
-  private:
-    // masses, energies, and momenta
-    two_body_state * state;
+    class dirac_spinor
+    {
+        public:
 
-    //Whether its an anti-particle or not
-    const bool ANTI_PARTICLE = false;
+        // Constructor
+        dirac_spinor(two_body_state * xstate, bool if_anti = false)
+        : state(xstate), ANTI_PARTICLE(if_anti)
+        {};
 
-    // Energy component
-    std::complex<double> omega(int sign, double s);
+        // Default destructor
+        ~dirac_spinor(){};
 
-    // angular component
-    double half_angle(int lam, double theta);
+        // Components
+        std::complex<double> component(int i, int lambda, double s, double theta);
+        std::complex<double> adjoint_component(int i, int lambda, double s, double theta);
 
-  public:
-    // Constructor
-    dirac_spinor(two_body_state * xstate, bool if_anti = false)
-    : state(xstate), ANTI_PARTICLE(if_anti)
-    {};
+        private:
 
-    // Default destructor
-    ~dirac_spinor(){};
+        // masses, energies, and momenta
+        two_body_state * state;
 
-    // Components
-    std::complex<double> component(int i, int lambda, double s, double theta);
-  	std::complex<double> adjoint_component(int i, int lambda, double s, double theta);
-  };
+        //Whether its an anti-particle or not
+        const bool ANTI_PARTICLE = false;
+
+        // Energy component
+        std::complex<double> omega(int sign, double s);
+
+        // angular component
+        double half_angle(int lam, double theta);
+    };
 };
 
 #endif

--- a/include/gamma_technology.hpp
+++ b/include/gamma_technology.hpp
@@ -17,8 +17,8 @@
 
 namespace jpacPhoto
 {
-	// Mostly minus metric
-	const double metric[4] = {1., -1., -1., -1.};
+    // Mostly minus metric
+    const double metric[4] = {1., -1., -1., -1.};
 
 	// Gamma matrix vector in Dirac basis
 	const std::complex<double> gamma_matrices[4][4][4] =
@@ -48,10 +48,10 @@ namespace jpacPhoto
 	// Gamma_5
 	const std::complex<double> gamma_5[4][4] =
 	{
-	  { 0., 0., 1., 0. },
-	  { 0., 0., 0., 1. },
-	  { 1., 0., 0., 0. },
-	  { 0., 1., 0., 0. }
+        { 0., 0., 1., 0. },
+        { 0., 0., 0., 1. },
+        { 1., 0., 0., 0. },
+        { 0., 1., 0., 0. }
 	};
 
 	// ---------------------------------------------------------------------------

--- a/include/helicities.hpp
+++ b/include/helicities.hpp
@@ -1,0 +1,124 @@
+// Arrays containing helicity combinations for indexing.
+// Moved to a seperate file to not clutter up reaction_kinematics.hpp
+//
+// Author:       Daniel Winney (2020)
+// Affiliation:  Joint Physics Analysis Center (JPAC)
+// Email:        dwinney@iu.edu
+// ---------------------------------------------------------------------------
+
+#ifndef _HELIC_COMBO_
+#define _HELIC_COMBO_
+
+#include <iostream>
+#include <vector>
+#include <array>
+
+namespace jpacPhoto
+{
+    const std::vector< std::array<int, 4> > spin_zero_helicities =
+    {
+    //  {  γ,  p,  S,  p'}
+        {  1, -1,  0, -1},
+        {  1, -1,  0,  1},
+        {  1,  1,  0, -1},
+        {  1,  1,  0,  1},
+        { -1, -1,  0, -1},
+        { -1, -1,  0,  1},
+        { -1,  1,  0, -1},
+        { -1,  1,  0,  1} 
+    };
+
+    const std::vector< std::array<int, 4> > spin_one_helicities =
+    {
+    //  {  γ,  p,  V,  p'}
+        {  1, -1,  1, -1},
+        {  1, -1,  1,  1},
+        {  1, -1,  0, -1},
+        {  1, -1,  0,  1},
+        {  1, -1, -1, -1},
+        {  1, -1, -1,  1},
+        {  1,  1,  1, -1},
+        {  1,  1,  1,  1},
+        {  1,  1,  0, -1},
+        {  1,  1,  0,  1},
+        {  1,  1, -1, -1},
+        {  1,  1, -1,  1},
+        { -1, -1,  1, -1},
+        { -1, -1,  1,  1},
+        { -1, -1,  0, -1},
+        { -1, -1,  0,  1},
+        { -1, -1, -1, -1},
+        { -1, -1, -1,  1},
+        { -1,  1,  1, -1},
+        { -1,  1,  1,  1},
+        { -1,  1,  0, -1},
+        { -1,  1,  0,  1}, 
+        { -1,  1, -1, -1},
+        { -1,  1, -1,  1}
+    };
+
+    const std::vector< std::array<int, 4> > spin_two_helicities =
+    {
+    //  {  γ,  p,  V,  p'}
+        {  1, -1,  2, -1},
+        {  1, -1,  2,  1},
+        {  1, -1,  1, -1},
+        {  1, -1,  1,  1},
+        {  1, -1,  0, -1},
+        {  1, -1,  0,  1},
+        {  1, -1, -1, -1},
+        {  1, -1, -1,  1},
+        {  1, -1, -2, -1},
+        {  1, -1, -2,  1},
+        {  1,  1,  2, -1},
+        {  1,  1,  2,  1},
+        {  1,  1,  1, -1},
+        {  1,  1,  1,  1},
+        {  1,  1,  0, -1},
+        {  1,  1,  0,  1},
+        {  1,  1, -1, -1},
+        {  1,  1, -1,  1},
+        {  1,  1, -2, -1},
+        {  1,  1, -2,  1},
+        { -1, -1,  2, -1},
+        { -1, -1,  2,  1},
+        { -1, -1,  1, -1},
+        { -1, -1,  1,  1},
+        { -1, -1,  0, -1},
+        { -1, -1,  0,  1},
+        { -1, -1, -1, -1},
+        { -1, -1, -1,  1},
+        { -1, -1, -2, -1},
+        { -1, -1, -2,  1},
+        { -1,  1,  2, -1},
+        { -1,  1,  2,  1},
+        { -1,  1,  1, -1},
+        { -1,  1,  1,  1},
+        { -1,  1,  0, -1},
+        { -1,  1,  0,  1}, 
+        { -1,  1, -1, -1},
+        { -1,  1, -1,  1},
+        { -1,  1, -2, -1},
+        { -1,  1, -2,  1}
+    };
+
+
+    inline std::vector<std::array<int, 4>> get_helicities(int J)
+    {
+        switch (J)
+        {   
+            case 0: return spin_zero_helicities;
+            case 1: return spin_one_helicities;
+            case 2: return spin_two_helicities;
+            default:
+            {
+                std::cout << "Error! Amplitudes for spin J = " << J << " not yet implemented. Quitting...\n";
+                exit(0);
+            }
+        };
+        
+        return {};
+    };
+};
+
+#endif

--- a/include/misc_math.hpp
+++ b/include/misc_math.hpp
@@ -42,9 +42,6 @@ namespace jpacPhoto
 
     // Wigner d-function for integer spin in terms of the cosine of theta not theta
     std::complex<double> wigner_d_int_cos(int j, int lam1, int lam2, double cos);
-
-    // Error message display function for the above
-    double wigner_error(int j, int lam1, int lam2, bool half);
 };
 
 #endif

--- a/include/misc_math.hpp
+++ b/include/misc_math.hpp
@@ -15,36 +15,36 @@
 
 namespace jpacPhoto
 {
-  template <typename T>
-  inline T Kallen(T x, T y, T z)
-  {
-    return x*x + y*y + z*z - 2. * (x*y + x*z + y*z);
-  };
+    template <typename T>
+    inline T Kallen(T x, T y, T z)
+    {
+        return x*x + y*y + z*z - 2. * (x*y + x*z + y*z);
+    };
 
-  std::complex<double> cgamma(std::complex<double> z, int OPT = 0);
+    std::complex<double> cgamma(std::complex<double> z, int OPT = 0);
 
-  inline unsigned int factorial(unsigned int n) 
-  {
-      if (n == 0)
+    inline unsigned int factorial(unsigned int n) 
+    {
+        if (n == 0)
         return 1;
-      return n * factorial(n - 1);
-  };
+        return n * factorial(n - 1);
+    };
 
-  // ---------------------------------------------------------------------------
-  // Wigner d-func coefficient of leading power
-  double wigner_leading_coeff(int j, int lam1, int lam2);
+    // ---------------------------------------------------------------------------
+    // Wigner d-func coefficient of leading power
+    double wigner_leading_coeff(int j, int lam1, int lam2);
 
-  // Wigner d-function for half-integer spin
-  double wigner_d_half(int j, int lam1, int lam2, double theta);
+    // Wigner d-function for half-integer spin
+    double wigner_d_half(int j, int lam1, int lam2, double theta);
 
-  // Wigner d-function for integer spin
-  double wigner_d_int(int j, int lam1, int lam2, double theta);
+    // Wigner d-function for integer spin
+    double wigner_d_int(int j, int lam1, int lam2, double theta);
 
-  // Wigner d-function for integer spin in terms of the cosine of theta not theta
-  std::complex<double> wigner_d_int_cos(int j, int lam1, int lam2, double cos);
+    // Wigner d-function for integer spin in terms of the cosine of theta not theta
+    std::complex<double> wigner_d_int_cos(int j, int lam1, int lam2, double cos);
 
-  // Error message display function for the above
-  double wigner_error(int j, int lam1, int lam2, bool half);
+    // Error message display function for the above
+    double wigner_error(int j, int lam1, int lam2, bool half);
 };
 
 #endif

--- a/include/polarization_vector.hpp
+++ b/include/polarization_vector.hpp
@@ -1,5 +1,4 @@
 // Class for the polarization vector of vector particles
-// coded up independently to not require ROOT to be installed
 //
 // Author:       Daniel Winney (2019)
 // Affiliation:  Joint Physics Analysis Center (JPAC)
@@ -21,24 +20,26 @@
 
 namespace jpacPhoto
 {
-  class polarization_vector
-  {
-  private:
-      two_body_state * state;
+    class polarization_vector
+    {
+        public:
 
-  public:
-    // Constructor
-    polarization_vector(two_body_state * xstate)
-      : state(xstate)
-    {};
-    
-    // Destructor
-    ~polarization_vector(){};
+        // Constructor
+        polarization_vector(two_body_state * xstate)
+            : state(xstate)
+        {};
 
-    // Components
-    std::complex<double> component(int i, int lambda, double s, double theta);
-    std::complex<double> conjugate_component(int i, int lambda, double s, double theta);
-  };
+        // Destructor
+        ~polarization_vector(){};
+
+        // Components
+        std::complex<double> component(int i, int lambda, double s, double theta);
+        std::complex<double> conjugate_component(int i, int lambda, double s, double theta);
+
+        private:
+        
+        two_body_state * state;
+    };
 };
 
 #endif

--- a/include/reaction_kinematics.hpp
+++ b/include/reaction_kinematics.hpp
@@ -29,211 +29,213 @@
 
 namespace jpacPhoto
 {
-  // ---------------------------------------------------------------------------
-  // The reaction kinematics object is intended to have all relevant kinematic quantities
-  // forthe reaction. Here you'll find the momenta and energies of all particles,
-  //  spinors for the baryons and polarization vectors for the gamma and produced meson
-  // ---------------------------------------------------------------------------
-
-  class reaction_kinematics
-  {
-  public: 
-    // Empty constructor,
-    // defaults to compton scattering: gamma p -> gamma p
-    reaction_kinematics()
-    : mX(0.), mX2(0.), 
-      mBar(mPro), mBar2(mPro2),
-      Q2(0.)
-    {
-      initial   = new two_body_state(0., mPro2);
-      eps_gamma = new polarization_vector(initial);
-      target    = new dirac_spinor(initial);
-
-      final     = new two_body_state(0., mPro2);
-      eps_vec   = new polarization_vector(final);
-      recoil    = new dirac_spinor(final);
-    };
-
-    // Constructor with a set mX, 
-    // defaults to proton as baryon and real photon
-    // string ID is deprecated but kept for backward compatibility
-    reaction_kinematics(double _mX, std::string id = "")
-    : mX(_mX), mX2(_mX*_mX),
-      mBar(mPro), mBar2(mPro2),
-      Q2(0.)
-    {
-      initial   = new two_body_state(0., mPro2);
-      eps_gamma = new polarization_vector(initial);
-      target    = new dirac_spinor(initial);
-
-      final     = new two_body_state(_mX*_mX, mPro2);
-      eps_vec   = new polarization_vector(final);
-      recoil    = new dirac_spinor(final);
-    };
-
-
-    // Constructor with a set mX and baryon mass mB
-    // defaults to real photon
-    reaction_kinematics(double _mX, double mB)
-    : mX(_mX), mX2(_mX*_mX),
-      mBar(mB), mBar2(mB*mB),
-      Q2(0.)
-    {
-      initial   = new two_body_state(0., mB*mB);
-      eps_gamma = new polarization_vector(initial);
-      target    = new dirac_spinor(initial);
-
-      final     = new two_body_state(_mX*_mX, mB*mB);
-      eps_vec   = new polarization_vector(final);
-      recoil    = new dirac_spinor(final);
-    };
-
-    // Constructor with a set mV and baryon mass mB
-    // and q2 > 0 for a virtual photon
-    reaction_kinematics(double _mX, double mB, double q2)
-    : mX(_mX), mX2(_mX*_mX),
-      mBar(mB), mBar2(mB*mB),
-      Q2(q2)
-    {
-      initial   = new two_body_state(-q2, mB*mB);
-      eps_gamma = new polarization_vector(initial);
-      target    = new dirac_spinor(initial);
-
-      final     = new two_body_state(_mX*_mX, mB*mB);
-      eps_vec   = new polarization_vector(final);
-      recoil    = new dirac_spinor(final);
-    };
-
-    // destructor
-    ~reaction_kinematics()
-    {
-      delete initial, final;
-      delete eps_gamma, eps_vec;
-      delete target, recoil;
-    }
-
-    double mX = 0., mX2 = 0.;     // mass and mass squared of the produced particle
-    double mBar = 0., mBar2 = 0.; // mass nd mass squared of the baryon 
-    double Q2 = 0.; // virtuality of the photon
-    inline double Wth(){ return (mX + mBar); }; // square root of the threshold
-    inline double sth(){ return Wth() * Wth(); }; // final state threshold
-
-    // Change the meson mass
-    inline void set_mX(double m)
-    {
-      mX  = m;
-      mX2 = m*m;
-
-      // also update the meson mass in two_body_state
-      final->set_mV2(m*m);
-    };
-    
-    inline void set_mX2(double m2)
-    {
-      mX  = sqrt(m2);
-      mX2 = m2;
-
-      // also update the meson mass in two_body_state
-      final->set_mV2(m2);
-    };
-
-    // Change the baryon mass squared
-    inline void set_mB2(double m2)
-    {
-      mBar  = sqrt(m2);
-      mBar2 = m2;
-
-      // also update the meson mass in two_body_state
-      initial->set_mB2(m2);
-      final->set_mB2(m2);
-    };
-    
-    // Change virtuality of the photon
-    // Q2 > 0
-    inline void set_Q2(double q2)
-    {
-      if (q2 > 0) { std::cout << "Caution! set_Q2(x) requires x > 0! \n"; }
-      Q2 = q2;
-      initial->set_mV2(-q2);
-    };
-    
     // ---------------------------------------------------------------------------
-    // Quantum numbers of produced meson. 
-    // abs(JP) = J  and sign(JP) = P
-    int JP = 1;
-    inline void set_JP(int _JP)
+    // The reaction kinematics object is intended to have all relevant kinematic quantities
+    // forthe reaction. Here you'll find the momenta and energies of all particles,
+    //  spinors for the baryons and polarization vectors for the gamma and produced meson
+    // ---------------------------------------------------------------------------
+
+    class reaction_kinematics
     {
-       JP = _JP; 
-       helicities = get_helicities( abs(_JP));
-       nAmps = helicities.size();
+        public: 
+        // Empty constructor,
+        // defaults to compton scattering: gamma p -> gamma p
+        reaction_kinematics()
+        : mX(0.), mX2(0.), 
+          mBar(mPro), mBar2(mPro2),
+          Q2(0.)
+        {
+            initial   = new two_body_state(0., mPro2);
+            eps_gamma = new polarization_vector(initial);
+            target    = new dirac_spinor(initial);
+
+            final     = new two_body_state(0., mPro2);
+            eps_vec   = new polarization_vector(final);
+            recoil    = new dirac_spinor(final);
+        };
+
+        // Constructor with a set mX and JP
+        // defaults to proton as baryon and real photon
+        // string ID is deprecated but kept for backward compatibility
+        reaction_kinematics(double _mX, std::string id = "")
+        : mX(_mX), mX2(_mX*_mX),
+          mBar(mPro), mBar2(mPro2),
+          Q2(0.)
+        {
+            initial   = new two_body_state(0., mPro2);
+            eps_gamma = new polarization_vector(initial);
+            target    = new dirac_spinor(initial);
+
+            final     = new two_body_state(_mX*_mX, mPro2);
+            eps_vec   = new polarization_vector(final);
+            recoil    = new dirac_spinor(final);
+        };
+
+
+        // Constructor with a set mX and baryon mass mB
+        // defaults to real photon
+        reaction_kinematics(double _mX, double mB)
+        : mX(_mX), mX2(_mX*_mX),
+          mBar(mB), mBar2(mB*mB),
+          Q2(0.)
+        {
+            initial   = new two_body_state(0., mB*mB);
+            eps_gamma = new polarization_vector(initial);
+            target    = new dirac_spinor(initial);
+
+            final     = new two_body_state(_mX*_mX, mB*mB);
+            eps_vec   = new polarization_vector(final);
+            recoil    = new dirac_spinor(final);
+        };
+
+        // Constructor with a set mV and baryon mass mB
+        // and q2 > 0 for a virtual photon
+        reaction_kinematics(double _mX, double mB, double q2)
+        : mX(_mX), mX2(_mX*_mX),
+          mBar(mB), mBar2(mB*mB),
+          Q2(q2)
+        {
+            initial   = new two_body_state(-q2, mB*mB);
+            eps_gamma = new polarization_vector(initial);
+            target    = new dirac_spinor(initial);
+
+            final     = new two_body_state(_mX*_mX, mB*mB);
+            eps_vec   = new polarization_vector(final);
+            recoil    = new dirac_spinor(final);
+        };
+
+        // destructor
+        ~reaction_kinematics()
+        {
+            delete initial, final;
+            delete eps_gamma, eps_vec;
+            delete target, recoil;
+        }
+
+        // ---------------------------------------------------------------------------
+        // Masses
+
+        double mX = 0., mX2 = 0.;     // mass and mass squared of the produced particle
+        double mBar = 0., mBar2 = 0.; // mass nd mass squared of the baryon 
+        double Q2 = 0.; // virtuality of the photon
+        inline double Wth(){ return (mX + mBar); }; // square root of the threshold
+        inline double sth(){ return Wth() * Wth(); }; // final state threshold
+
+        // Change the meson mass
+        inline void set_mX(double m)
+        {
+            mX  = m;
+            mX2 = m*m;
+
+            // also update the meson mass in two_body_state
+            final->set_mV2(m*m);
+        };
+
+        inline void set_mX2(double m2)
+        {
+            mX  = sqrt(m2);
+            mX2 = m2;
+
+            // also update the meson mass in two_body_state
+            final->set_mV2(m2);
+        };
+
+        // Change the baryon mass squared
+        inline void set_mB2(double m2)
+        {
+            mBar  = sqrt(m2);
+            mBar2 = m2;
+
+            // also update the meson mass in two_body_state
+            initial->set_mB2(m2);
+            final->set_mB2(m2);
+        };
+
+        // Change virtuality of the photon
+        // Q2 > 0
+        inline void set_Q2(double q2)
+        {
+            if (q2 > 0) { std::cout << "Caution! set_Q2(x) requires x > 0! \n"; }
+            Q2 = q2;
+            initial->set_mV2(-q2);
+        };
+
+        // ---------------------------------------------------------------------------
+        // Quantum numbers of produced meson. 
+        std::array<int,2> JP = {1, 1};
+        inline void set_JP(int _J, int _P)
+        { 
+            JP = {_J, _P};
+            helicities = get_helicities(_J);
+            nAmps = helicities.size();
+        };
+
+        // Helicity configurations
+        // Photon [0], Incoming Proton [1], Produced meson [2], Outgoing Proton [3]
+        int nAmps = 24; 
+        std::vector< std::array<int, 4> > helicities = spin_one_helicities;
+
+        //--------------------------------------------------------------------------
+        two_body_state * initial,  * final;
+        polarization_vector * eps_vec, * eps_gamma;
+        dirac_spinor * target, * recoil;
+
+        // Get s-channel scattering angle from invariants
+        inline double z_s(double s, double t)
+        {
+            std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
+            std::complex<double> E1E3   = initial->energy_V(s) * final->energy_V(s);
+
+            double result = t - mX2 + Q2 + 2.*abs(E1E3);
+            result /= 2. * abs(qdotqp);
+
+            return result;
+        };
+
+        // Scattering angle in the s-channel
+        // Use TMath::ACos instead of std::acos because its safer at the end points
+        inline double theta_s(double s, double t)
+        {
+            return TMath::ACos( z_s(s, t) );
+        };
+
+        // Invariant variables
+        inline double t_man(double s, double theta)
+        {
+            std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
+            std::complex<double> E1E3 = initial->energy_V(s) * final->energy_V(s);
+
+            return mX2 - Q2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
+        };
+
+        inline double u_man(double s, double theta)
+        { 
+            return mX2 - Q2 + 2. * mBar2 - s - t_man(s, theta);
+        };
+
+        // Scattering angles in t and u channel frames
+        inline std::complex<double> z_t(double s, double theta)
+        {
+            double t = t_man(s, theta);
+            std::complex<double> p_t = sqrt(xr * t - 4. * mBar2) / 2.;
+            std::complex<double> q_t = sqrt(xr * Kallen(t, mX2, -Q2)) / sqrt(xr * 4. * t);
+
+            std::complex<double> result;
+            result = 2. * s + t - 2. * mBar2 - mX2 + Q2; // s - u
+            result /= 4. * p_t * q_t;
+
+            return result;
+        };
+
+        inline std::complex<double> z_u(double s, double theta)
+        {
+            // TODO: fix this
+            std::cout << "z_u not implimented yet i fucked up here :p\n";
+            std::cout << "if youre seeing this message email me and yell at me because i forgot\n";
+            
+            return xr;
+        };
     };
-
-    // Helicity configurations
-    // Photon [0], Incoming Proton [1], Produced meson [2], Outgoing Proton [3]
-    int nAmps = 24; 
-    std::vector< std::array<int, 4> > helicities = spin_one_helicities;
-
-    //--------------------------------------------------------------------------
-    two_body_state * initial,  * final;
-    polarization_vector * eps_vec, * eps_gamma;
-    dirac_spinor * target, * recoil;
-
-    // Get s-channel scattering angle from invariants
-    inline double z_s(double s, double t)
-    {
-      std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
-      std::complex<double> E1E3   = initial->energy_V(s) * final->energy_V(s);
-
-      double result = t - mX2 + Q2 + 2.*abs(E1E3);
-      result /= 2. * abs(qdotqp);
-
-      return result;
-    };
-
-    // Scattering angle in the s-channel
-    // Use TMath::ACos instead of std::acos because its safer at the end points
-    inline double theta_s(double s, double t)
-    {
-      return TMath::ACos( z_s(s, t) );
-    };
-
-    // Invariant variables
-    inline double t_man(double s, double theta)
-    {
-      std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
-      std::complex<double> E1E3 = initial->energy_V(s) * final->energy_V(s);
-
-      return mX2 - Q2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
-    };
-
-    inline double u_man(double s, double theta)
-    { 
-      return mX2 - Q2 + 2. * mBar2 - s - t_man(s, theta);
-    };
-
-    // Scattering angles in t and u channel frames
-    inline std::complex<double> z_t(double s, double theta)
-    {
-      double t = t_man(s, theta);
-      std::complex<double> p_t = sqrt(xr * t - 4. * mBar2) / 2.;
-      std::complex<double> q_t = sqrt(xr * Kallen(t, mX2, -Q2)) / sqrt(xr * 4. * t);
-
-      std::complex<double> result;
-      result = 2. * s + t - 2. * mBar2 - mX2 + Q2; // s - u
-      result /= 4. * p_t * q_t;
-
-      return result;
-    };
-
-    inline std::complex<double> z_u(double s, double theta)
-    {
-      // TODO: fix this
-      std::cout << "z_u not implimented yet i fucked up here :p\n";
-      std::cout << "if youre seeing this message email me and yell at me because i forgot\n";
-      
-      return xr;
-    };
-  };
 };
 
 #endif

--- a/include/reaction_kinematics.hpp
+++ b/include/reaction_kinematics.hpp
@@ -41,9 +41,6 @@ namespace jpacPhoto
         // Empty constructor,
         // defaults to compton scattering: gamma p -> gamma p
         reaction_kinematics()
-        : mX(0.), mX2(0.), 
-          mBar(mPro), mBar2(mPro2),
-          Q2(0.)
         {
             initial   = new two_body_state(0., mPro2);
             eps_gamma = new polarization_vector(initial);
@@ -58,9 +55,7 @@ namespace jpacPhoto
         // defaults to proton as baryon and real photon
         // string ID is deprecated but kept for backward compatibility
         reaction_kinematics(double _mX, std::string id = "")
-        : mX(_mX), mX2(_mX*_mX),
-          mBar(mPro), mBar2(mPro2),
-          Q2(0.)
+        : mX(_mX), mX2(_mX*_mX)
         {
             initial   = new two_body_state(0., mPro2);
             eps_gamma = new polarization_vector(initial);
@@ -72,34 +67,34 @@ namespace jpacPhoto
         };
 
 
-        // Constructor with a set mX and baryon mass mB
+        // Constructor with a set mX and baryon mass mR
         // defaults to real photon
-        reaction_kinematics(double _mX, double mB)
+        reaction_kinematics(double _mX, double _mR)
         : mX(_mX), mX2(_mX*_mX),
-          mBar(mB), mBar2(mB*mB),
-          Q2(0.)
+          mR(_mR), mR2(_mR*_mR)
         {
-            initial   = new two_body_state(0., mB*mB);
+            initial   = new two_body_state(0., mPro2);
             eps_gamma = new polarization_vector(initial);
             target    = new dirac_spinor(initial);
 
-            final     = new two_body_state(_mX*_mX, mB*mB);
+            final     = new two_body_state(_mX*_mX, _mR*_mR);
             eps_vec   = new polarization_vector(final);
             recoil    = new dirac_spinor(final);
         };
 
-        // Constructor with a set mV and baryon mass mB
-        // and q2 > 0 for a virtual photon
-        reaction_kinematics(double _mX, double mB, double q2)
+        // Constructor with a set mV and baryon mass mR
+        // and massive beam and target
+        reaction_kinematics(double _mX, double _mR, double _mT, double _mB = 0.)
         : mX(_mX), mX2(_mX*_mX),
-          mBar(mB), mBar2(mB*mB),
-          Q2(q2)
+          mR(_mR), mR2(_mR*_mR),
+          mB(_mB), mB2(_mB*_mB),
+          mT(_mT), mT2(_mT*_mT)
         {
-            initial   = new two_body_state(-q2, mB*mB);
+            initial   = new two_body_state(_mB*_mB, _mT*_mT);
             eps_gamma = new polarization_vector(initial);
             target    = new dirac_spinor(initial);
 
-            final     = new two_body_state(_mX*_mX, mB*mB);
+            final     = new two_body_state(_mX*_mX, _mR*_mR);
             eps_vec   = new polarization_vector(final);
             recoil    = new dirac_spinor(final);
         };
@@ -114,11 +109,14 @@ namespace jpacPhoto
 
         // ---------------------------------------------------------------------------
         // Masses
+        
+        double mB = 0., mB2 = 0.;       // mass and mass squared of the "beam" 
+        double mX = 0., mX2 = 0.;       // mass and mass squared of the produced particle
 
-        double mX = 0., mX2 = 0.;     // mass and mass squared of the produced particle
-        double mBar = 0., mBar2 = 0.; // mass nd mass squared of the baryon 
-        double Q2 = 0.; // virtuality of the photon
-        inline double Wth(){ return (mX + mBar); }; // square root of the threshold
+        double mT = mPro, mT2 = mPro2;  // mass of the target, assumed to be proton unless overriden
+        double mR = mPro, mR2 = mPro2;  // mass of the recoil baryon, assumed to be proton unless overriden
+
+        inline double Wth(){ return (mX + mR); }; // square root of the threshold
         inline double sth(){ return Wth() * Wth(); }; // final state threshold
 
         // Change the meson mass
@@ -140,23 +138,12 @@ namespace jpacPhoto
             final->set_mV2(m2);
         };
 
-        // Change the baryon mass squared
-        inline void set_mB2(double m2)
-        {
-            mBar  = sqrt(m2);
-            mBar2 = m2;
-
-            // also update the meson mass in two_body_state
-            initial->set_mB2(m2);
-            final->set_mB2(m2);
-        };
-
         // Change virtuality of the photon
         // Q2 > 0
         inline void set_Q2(double q2)
         {
             if (q2 > 0) { std::cout << "Caution! set_Q2(x) requires x > 0! \n"; }
-            Q2 = q2;
+            mB2 = -q2;
             initial->set_mV2(-q2);
         };
 
@@ -186,7 +173,7 @@ namespace jpacPhoto
             std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
             std::complex<double> E1E3   = initial->energy_V(s) * final->energy_V(s);
 
-            double result = t - mX2 + Q2 + 2.*abs(E1E3);
+            double result = t - mX2 - mB2 + 2.*abs(E1E3);
             result /= 2. * abs(qdotqp);
 
             return result;
@@ -203,25 +190,25 @@ namespace jpacPhoto
         inline double t_man(double s, double theta)
         {
             std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
-            std::complex<double> E1E3 = initial->energy_V(s) * final->energy_V(s);
+            std::complex<double> E1E3   = initial->energy_V(s) * final->energy_V(s);
 
-            return mX2 - Q2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
+            return mX2 + mB2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
         };
 
         inline double u_man(double s, double theta)
         { 
-            return mX2 - Q2 + 2. * mBar2 - s - t_man(s, theta);
+            return mX2 + mB2 + mT2 + mR2 - s - t_man(s, theta);
         };
 
         // Scattering angles in t and u channel frames
         inline std::complex<double> z_t(double s, double theta)
         {
             double t = t_man(s, theta);
-            std::complex<double> p_t = sqrt(xr * t - 4. * mBar2) / 2.;
-            std::complex<double> q_t = sqrt(xr * Kallen(t, mX2, -Q2)) / sqrt(xr * 4. * t);
+            std::complex<double> p_t = sqrt(xr * Kallen(t, mT2, mR2)) / sqrt(xr * 4. * t);
+            std::complex<double> q_t = sqrt(xr * Kallen(t, mX2, mB2)) / sqrt(xr * 4. * t);
 
             std::complex<double> result;
-            result = 2. * s + t - 2. * mBar2 - mX2 + Q2; // s - u
+            result = 2. * s + t - mT2 - mR2 - mX2 - mB2; // s - u
             result /= 4. * p_t * q_t;
 
             return result;

--- a/include/reaction_kinematics.hpp
+++ b/include/reaction_kinematics.hpp
@@ -18,9 +18,11 @@
 #include "two_body_state.hpp"
 #include "dirac_spinor.hpp"
 #include "polarization_vector.hpp"
+#include "helicities.hpp"
 
 #include "TMath.h"
 
+#include <array>
 #include <vector>
 #include <string>
 #include <cmath>
@@ -116,14 +118,13 @@ namespace jpacPhoto
     inline double Wth(){ return (mX + mBar); }; // square root of the threshold
     inline double sth(){ return Wth() * Wth(); }; // final state threshold
 
-
-    // Change the vector mass
+    // Change the meson mass
     inline void set_mX(double m)
     {
       mX  = m;
       mX2 = m*m;
 
-      // also update the vector mass in two_body_state
+      // also update the meson mass in two_body_state
       final->set_mV2(m*m);
     };
     
@@ -132,7 +133,7 @@ namespace jpacPhoto
       mX  = sqrt(m2);
       mX2 = m2;
 
-      // also update the vector mass in two_body_state
+      // also update the meson mass in two_body_state
       final->set_mV2(m2);
     };
 
@@ -142,7 +143,7 @@ namespace jpacPhoto
       mBar  = sqrt(m2);
       mBar2 = m2;
 
-      // also update the baryon mass in two_body_state
+      // also update the meson mass in two_body_state
       initial->set_mB2(m2);
       final->set_mB2(m2);
     };
@@ -156,36 +157,21 @@ namespace jpacPhoto
       initial->set_mV2(-q2);
     };
     
-    // Helicity configurations
-    // Photon [0], Incoming Proton [1], Vector meson [2], Outgoing Proton [3], hel_id [4]
-    std::vector< std::vector<int> > helicities =
+    // ---------------------------------------------------------------------------
+    // Quantum numbers of produced meson. 
+    // abs(JP) = J  and sign(JP) = P
+    int JP = 1;
+    inline void set_JP(int _JP)
     {
-    //  {  γ,  p,  V,  p'}
-        {  1, -1,  1, -1 ,  0},
-        {  1, -1,  1,  1 ,  1},
-        {  1, -1,  0, -1 ,  2},
-        {  1, -1,  0,  1 ,  3},
-        {  1, -1, -1, -1 ,  4},
-        {  1, -1, -1,  1 ,  5},
-        {  1,  1,  1, -1 ,  6},
-        {  1,  1,  1,  1 ,  7},
-        {  1,  1,  0, -1 ,  8},
-        {  1,  1,  0,  1 ,  9},
-        {  1,  1, -1, -1 , 10},
-        {  1,  1, -1,  1 , 11},
-        { -1, -1,  1, -1 , 12},
-        { -1, -1,  1,  1 , 13},
-        { -1, -1,  0, -1 , 14},
-        { -1, -1,  0,  1 , 15},
-        { -1, -1, -1, -1 , 16},
-        { -1, -1, -1,  1 , 17},
-        { -1,  1,  1, -1 , 18},
-        { -1,  1,  1,  1 , 19},
-        { -1,  1,  0, -1 , 20},
-        { -1,  1,  0,  1 , 21}, 
-        { -1,  1, -1, -1 , 22},
-        { -1,  1, -1,  1 , 23},
+       JP = _JP; 
+       helicities = get_helicities( abs(_JP));
+       nAmps = helicities.size();
     };
+
+    // Helicity configurations
+    // Photon [0], Incoming Proton [1], Produced meson [2], Outgoing Proton [3]
+    int nAmps = 24; 
+    std::vector< std::array<int, 4> > helicities = spin_one_helicities;
 
     //--------------------------------------------------------------------------
     two_body_state * initial,  * final;

--- a/include/reaction_kinematics.hpp
+++ b/include/reaction_kinematics.hpp
@@ -1,7 +1,10 @@
 // Class to contain all relevant kinematic quantities. The kinematics of the reaction
-// gamma p -> V p' is entirely determined by specifying the mass of the vector particle
+// gamma p -> X p' is entirely determined by specifying the mass of the vector particle.
 //
-// Author:       Daniel Winney (2019)
+// Additional options to include virtual photon and different baryons (e.g. gamma p -> X Lambda_c) 
+// also available
+//
+// Author:       Daniel Winney (2020)
 // Affiliation:  Joint Physics Analysis Center (JPAC)
 // Email:        dwinney@iu.edu
 // ---------------------------------------------------------------------------
@@ -27,9 +30,7 @@ namespace jpacPhoto
   // ---------------------------------------------------------------------------
   // The reaction kinematics object is intended to have all relevant kinematic quantities
   // forthe reaction. Here you'll find the momenta and energies of all particles,
-  //  spinors for the nucleons and polarization vectors for the gamma and vector meson
-  //
-  // Additionally helicity combinations are stored for easier access
+  //  spinors for the baryons and polarization vectors for the gamma and produced meson
   // ---------------------------------------------------------------------------
 
   class reaction_kinematics
@@ -38,7 +39,7 @@ namespace jpacPhoto
     // Empty constructor,
     // defaults to compton scattering: gamma p -> gamma p
     reaction_kinematics()
-    : mVec(0.), mVec2(0.), 
+    : mX(0.), mX2(0.), 
       mBar(mPro), mBar2(mPro2),
       Q2(0.)
     {
@@ -51,11 +52,11 @@ namespace jpacPhoto
       recoil    = new dirac_spinor(final);
     };
 
-    // Constructor with a set vector mass mV, 
+    // Constructor with a set mX, 
     // defaults to proton as baryon and real photon
     // string ID is deprecated but kept for backward compatibility
-    reaction_kinematics(double mV, std::string id = "")
-    : mVec(mV), mVec2(mV*mV),
+    reaction_kinematics(double _mX, std::string id = "")
+    : mX(_mX), mX2(_mX*_mX),
       mBar(mPro), mBar2(mPro2),
       Q2(0.)
     {
@@ -63,16 +64,16 @@ namespace jpacPhoto
       eps_gamma = new polarization_vector(initial);
       target    = new dirac_spinor(initial);
 
-      final     = new two_body_state(mV*mV, mPro2);
+      final     = new two_body_state(_mX*_mX, mPro2);
       eps_vec   = new polarization_vector(final);
       recoil    = new dirac_spinor(final);
     };
 
 
-    // Constructor with a set mV and baryon mass mB
+    // Constructor with a set mX and baryon mass mB
     // defaults to real photon
-    reaction_kinematics(double mV, double mB)
-    : mVec(mV), mVec2(mV*mV),
+    reaction_kinematics(double _mX, double mB)
+    : mX(_mX), mX2(_mX*_mX),
       mBar(mB), mBar2(mB*mB),
       Q2(0.)
     {
@@ -80,15 +81,15 @@ namespace jpacPhoto
       eps_gamma = new polarization_vector(initial);
       target    = new dirac_spinor(initial);
 
-      final     = new two_body_state(mV*mV, mB*mB);
+      final     = new two_body_state(_mX*_mX, mB*mB);
       eps_vec   = new polarization_vector(final);
       recoil    = new dirac_spinor(final);
     };
 
     // Constructor with a set mV and baryon mass mB
     // and q2 > 0 for a virtual photon
-    reaction_kinematics(double mV, double mB, double q2)
-    : mVec(mV), mVec2(mV*mV),
+    reaction_kinematics(double _mX, double mB, double q2)
+    : mX(_mX), mX2(_mX*_mX),
       mBar(mB), mBar2(mB*mB),
       Q2(q2)
     {
@@ -96,7 +97,7 @@ namespace jpacPhoto
       eps_gamma = new polarization_vector(initial);
       target    = new dirac_spinor(initial);
 
-      final     = new two_body_state(mV*mV, mB*mB);
+      final     = new two_body_state(_mX*_mX, mB*mB);
       eps_vec   = new polarization_vector(final);
       recoil    = new dirac_spinor(final);
     };
@@ -109,27 +110,27 @@ namespace jpacPhoto
       delete target, recoil;
     }
 
-    double mVec = 0., mVec2 = 0.; // mass and mass squared of the vector particle
+    double mX = 0., mX2 = 0.;     // mass and mass squared of the produced particle
     double mBar = 0., mBar2 = 0.; // mass nd mass squared of the baryon 
     double Q2 = 0.; // virtuality of the photon
-    inline double Wth(){ return (mVec + mBar); }; // square root of the threshold
+    inline double Wth(){ return (mX + mBar); }; // square root of the threshold
     inline double sth(){ return Wth() * Wth(); }; // final state threshold
 
 
     // Change the vector mass
-    inline void set_vectormass(double m)
+    inline void set_mX(double m)
     {
-      mVec  = m;
-      mVec2 = m*m;
+      mX  = m;
+      mX2 = m*m;
 
       // also update the vector mass in two_body_state
       final->set_mV2(m*m);
     };
     
-    inline void set_mV2(double m2)
+    inline void set_mX2(double m2)
     {
-      mVec  = sqrt(m2);
-      mVec2 = m2;
+      mX  = sqrt(m2);
+      mX2 = m2;
 
       // also update the vector mass in two_body_state
       final->set_mV2(m2);
@@ -197,7 +198,7 @@ namespace jpacPhoto
       std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
       std::complex<double> E1E3   = initial->energy_V(s) * final->energy_V(s);
 
-      double result = t - mVec2 + Q2 + 2.*abs(E1E3);
+      double result = t - mX2 + Q2 + 2.*abs(E1E3);
       result /= 2. * abs(qdotqp);
 
       return result;
@@ -216,12 +217,12 @@ namespace jpacPhoto
       std::complex<double> qdotqp = initial->momentum(s) * final->momentum(s);
       std::complex<double> E1E3 = initial->energy_V(s) * final->energy_V(s);
 
-      return mVec*mVec - Q2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
+      return mX2 - Q2 - 2. * abs(E1E3) + 2. * abs(qdotqp) * cos(theta);
     };
 
     inline double u_man(double s, double theta)
     { 
-      return mVec2 - Q2 + 2. * mBar2 - s - t_man(s, theta);
+      return mX2 - Q2 + 2. * mBar2 - s - t_man(s, theta);
     };
 
     // Scattering angles in t and u channel frames
@@ -229,10 +230,10 @@ namespace jpacPhoto
     {
       double t = t_man(s, theta);
       std::complex<double> p_t = sqrt(xr * t - 4. * mBar2) / 2.;
-      std::complex<double> q_t = sqrt(xr * Kallen(t, mVec2, -Q2)) / sqrt(xr * 4. * t);
+      std::complex<double> q_t = sqrt(xr * Kallen(t, mX2, -Q2)) / sqrt(xr * 4. * t);
 
       std::complex<double> result;
-      result = 2. * s + t - 2. * mBar2 - mVec2 + Q2; // s - u
+      result = 2. * s + t - 2. * mBar2 - mX2 + Q2; // s - u
       result /= 4. * p_t * q_t;
 
       return result;

--- a/include/regge_trajectory.hpp
+++ b/include/regge_trajectory.hpp
@@ -15,69 +15,72 @@
 
 class regge_trajectory
 {
-public:
-  // constructor
-  regge_trajectory(std::string name = "")
-  : parent(name)
-  {};
+    public:
 
-  regge_trajectory(int sig, std::string name = "")
-  : signature(sig), parent(name)
-  {};
+    // constructor
+    regge_trajectory(std::string name = "")
+    : parent(name)
+    {};
 
-  // copy constructor
-  regge_trajectory(const regge_trajectory & old)
-  : parent(old.parent), signature(old.signature)
-  {};
+    regge_trajectory(int sig, std::string name = "")
+    : signature(sig), parent(name)
+    {};
 
-  // Only need a function to evaluate the trajectory at some s
-  virtual std::complex<double> eval(double s) = 0;
+    // copy constructor
+    regge_trajectory(const regge_trajectory & old)
+    : parent(old.parent), signature(old.signature)
+    {};
 
-  // These parameters define the trajectory
-  // name, spin, and mass of the lowest lying resonance on the parent trajectory
-  std::string parent;
-  int signature;
+    // Only need a function to evaluate the trajectory at some s
+    virtual std::complex<double> eval(double s) = 0;
+
+    // These parameters define the trajectory
+    // name, spin, and mass of the lowest lying resonance on the parent trajectory
+    std::string parent;
+    int signature;
 };
 
 
 // Basic linear regge_trajectory
 class linear_trajectory : public regge_trajectory
 {
-private:
-  // Intercept and slope
-  double a0, aprime;
+    private:
 
-public:
-  // Empty constructor
-  linear_trajectory(){};
+    // Intercept and slope
+    double a0, aprime;
 
-  // Parameterized constructor
-  linear_trajectory(int sig, double inter, double slope, std::string name = "")
-  : regge_trajectory(sig, name),
-    a0(inter), aprime(slope)
-  {};
+    public:
 
-  // copy Constructor
-  linear_trajectory(const linear_trajectory & old)
-  : regge_trajectory(old),
-    a0(old.a0), aprime(old.aprime)
-  {};
+    // Empty constructor
+    linear_trajectory(){};
 
-  // Setting utility
-  void set_params(double inter, double slope)
-  {
-    a0 = inter; aprime = slope;
-  };
+    // Parameterized constructor
+    linear_trajectory(int sig, double inter, double slope, std::string name = "")
+    : regge_trajectory(sig, name),
+      a0(inter), aprime(slope)
+    {};
 
-  std::complex<double> eval(double s)
-  {
-    return a0 + aprime * s;
-  }
+    // copy Constructor
+    linear_trajectory(const linear_trajectory & old)
+    : regge_trajectory(old),
+      a0(old.a0), aprime(old.aprime)
+    {};
 
-  double slope()
-  {
-    return aprime;
-  }
+    // Setting utility
+    void set_params(double inter, double slope)
+    {
+        a0 = inter; aprime = slope;
+    };
+
+    std::complex<double> eval(double s)
+    {
+        return a0 + aprime * s;
+    };
+
+    double slope()
+    {
+        return aprime;
+    };
 };
 
 #endif

--- a/include/regge_trajectory.hpp
+++ b/include/regge_trajectory.hpp
@@ -34,6 +34,8 @@ class regge_trajectory
     // Only need a function to evaluate the trajectory at some s
     virtual std::complex<double> eval(double s) = 0;
 
+    virtual std::complex<double> slope(double s = 0.){return 0.;};
+
     // These parameters define the trajectory
     // name, spin, and mass of the lowest lying resonance on the parent trajectory
     std::string parent;
@@ -77,7 +79,7 @@ class linear_trajectory : public regge_trajectory
         return a0 + aprime * s;
     };
 
-    double slope()
+    std::complex<double> slope(double s = 0.)
     {
         return aprime;
     };

--- a/include/two_body_state.hpp
+++ b/include/two_body_state.hpp
@@ -28,68 +28,70 @@ namespace jpacPhoto
 {
   class two_body_state
   {
-  private:
-    double mV2; // Vector mass
-    double mB2; // Baryon mass (allowed to be float for N* or Δ)
+        private:
 
-  public:
-    // Constructor
-    two_body_state(double _mV2, double _mB2)
-    : mV2(_mV2), mB2(_mB2)
-    {};
+        double mV2; // Vector mass
+        double mB2; // Baryon mass (allowed to be float for N* or Δ)
 
-    // return mass
-    inline double get_mV() 
-    { 
-      if (mV2 >= 0.) 
-      {
-        return sqrt(mV2);
-      }
-      else
-      {
-        return sqrt(-mV2);
-      }
+        public:
+
+        // Constructor
+        two_body_state(double _mV2, double _mB2)
+        : mV2(_mV2), mB2(_mB2)
+        {};
+
+        // return mass
+        inline double get_mV() 
+        { 
+            if (mV2 >= 0.) 
+            {
+                return sqrt(mV2);
+            }
+            else
+            {
+                return sqrt(-mV2);
+            }
+        };
+
+        inline double get_mB() { return sqrt(mB2); };
+
+        // Return mass squared
+        inline double get_mV2() { return mV2; };
+        inline double get_mB2() { return mB2; };
+
+        // set masses independently
+        inline void set_mV2(double _mV2)
+        {
+            mV2 = _mV2;
+        };
+
+        inline void set_mB2(double _mB2)
+        {
+            mB2 = _mB2;
+        };
+
+        // Momenta
+        // V is always particle 1 in + z direction, 
+        inline std::complex<double> momentum(double s)
+        {
+            return sqrt( Kallen(xr * s, xr * mV2, xr * mB2)) / (2. * sqrt(xr * s));
+        };
+
+        // Energies
+        inline std::complex<double> energy_V(double s)
+        {
+            return (s + mV2 - mB2) / (2. * sqrt(xr * s));
+        };
+
+        inline std::complex<double> energy_B(double s)
+        {
+            return (s - mV2 + mB2) / (2. * sqrt(xr * s));
+        };
+
+        // Full 4-momenta 
+        std::complex<double> q(int mu, double s, double theta); // 4vector of vector, particle 1
+        std::complex<double> p(int mu, double s, double theta); // 4vector of baryon, particle 2
     };
-
-    inline double get_mB() { return sqrt(mB2); };
-
-    // Return mass squared
-    inline double get_mV2() { return mV2; };
-    inline double get_mB2() { return mB2; };
-
-    // set masses independently
-    inline void set_mV2(double _mV2)
-    {
-      mV2 = _mV2;
-    };
-
-    inline void set_mB2(double _mB2)
-    {
-      mB2 = _mB2;
-    };
-
-    // Momenta
-    // V is always particle 1 in + z direction, 
-    inline std::complex<double> momentum(double s)
-    {
-      return sqrt( Kallen(xr * s, xr * mV2, xr * mB2)) / (2. * sqrt(xr * s));
-    };
-
-    // Energies
-    inline std::complex<double> energy_V(double s)
-    {
-      return (s + mV2 - mB2) / (2. * sqrt(xr * s));
-    };
-
-    inline std::complex<double> energy_B(double s)
-    {
-      return (s - mV2 + mB2) / (2. * sqrt(xr * s));
-    };
-
-    // Full 4-momenta 
-    std::complex<double> q(int mu, double s, double theta); // 4vector of vector, particle 1
-    std::complex<double> p(int mu, double s, double theta); // 4vector of baryon, particle 2
-  };
 };
 
 #endif

--- a/src/amplitudes/amplitude_sum.cpp
+++ b/src/amplitudes/amplitude_sum.cpp
@@ -9,7 +9,7 @@
 #include "amplitudes/amplitude_sum.hpp"
 
 // Evaluate the sum for given set of helicites, and mandelstam invariant s and t
-std::complex<double> jpacPhoto::amplitude_sum::helicity_amplitude(std::vector<int> helicities, double s, double t)
+std::complex<double> jpacPhoto::amplitude_sum::helicity_amplitude(std::array<int, 4> helicities, double s, double t)
 {
   std::complex<double> result = 0.;
   for (int i = 0; i < amps.size(); i++)

--- a/src/amplitudes/amplitude_sum.cpp
+++ b/src/amplitudes/amplitude_sum.cpp
@@ -11,11 +11,11 @@
 // Evaluate the sum for given set of helicites, and mandelstam invariant s and t
 std::complex<double> jpacPhoto::amplitude_sum::helicity_amplitude(std::array<int, 4> helicities, double s, double t)
 {
-  std::complex<double> result = 0.;
-  for (int i = 0; i < amps.size(); i++)
-  {
-    result += amps[i]->helicity_amplitude(helicities, s, t);
-  }
+    std::complex<double> result = 0.;
+    for (int i = 0; i < amps.size(); i++)
+    {
+        result += amps[i]->helicity_amplitude(helicities, s, t);
+    }
 
-  return result;
+    return result;
 };

--- a/src/amplitudes/baryon_resonance.cpp
+++ b/src/amplitudes/baryon_resonance.cpp
@@ -77,5 +77,7 @@ std::complex<double> jpacPhoto::baryon_resonance::hadronic_coupling(int lam_f)
     std::complex<double> gpsi;
     gpsi = g * pow(kinematics->final->momentum(s), l_min);
 
+    (lam_f < 0) ? (gpsi *= double(naturality)) : (gpsi *= 1.);
+
     return gpsi;
 };

--- a/src/amplitudes/baryon_resonance.cpp
+++ b/src/amplitudes/baryon_resonance.cpp
@@ -8,7 +8,7 @@
 #include "amplitudes/baryon_resonance.hpp"
 
 // Combined amplitude as a Breit-Wigner with the residue as the prodect of hadronic and photo-couplings
-std::complex<double> jpacPhoto::baryon_resonance::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::baryon_resonance::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_i = 2 * helicities[0] - helicities[1];
   int lam_f = 2 * helicities[2] - helicities[3];

--- a/src/amplitudes/baryon_resonance.cpp
+++ b/src/amplitudes/baryon_resonance.cpp
@@ -10,69 +10,72 @@
 // Combined amplitude as a Breit-Wigner with the residue as the prodect of hadronic and photo-couplings
 std::complex<double> jpacPhoto::baryon_resonance::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_i = 2 * helicities[0] - helicities[1];
-  int lam_f = 2 * helicities[2] - helicities[3];
+    int lam_i = 2 * helicities[0] - helicities[1];
+    int lam_f = 2 * helicities[2] - helicities[3];
 
-  // update save values of energies and angle
-  s = xs; t = xt; theta = kinematics->theta_s(xs, xt);
+    // update save values of energies and angle
+    s = xs; t = xt; theta = kinematics->theta_s(xs, xt);
 
-  std::complex<double> residue = 1.;
-  residue  = photo_coupling(lam_i);
-  residue *= hadronic_coupling(lam_f);
-  residue *= threshold_factor(1.5);
+    std::complex<double> residue = 1.;
+    residue  = photo_coupling(lam_i);
+    residue *= hadronic_coupling(lam_f);
+    residue *= threshold_factor(1.5);
 
-  residue *= wigner_d_half(J, lam_i, lam_f, theta);
-  residue /= (s + xi * mRes * gamRes - mRes*mRes);
+    residue *= wigner_d_half(J, lam_i, lam_f, theta);
+    residue /= (s + xi * mRes * gamRes - mRes*mRes);
 
-  return residue;
+    return residue;
 };
 
 // Ad-hoc threshold factor to kill the resonance at threshold
 double jpacPhoto::baryon_resonance::threshold_factor(double beta)
 {
-  double result = pow((s - kinematics->sth()) / s, beta);
-  result /= pow((mRes*mRes - kinematics->sth()) / (mRes*mRes), beta);
+    double result = pow((s - kinematics->sth()) / s, beta);
+    result /= pow((mRes*mRes - kinematics->sth()) / (mRes*mRes), beta);
 
-  return result;
+    return result;
 };
 
 // Photoexcitation helicity amplitude for the process gamma p -> R
 std::complex<double> jpacPhoto::baryon_resonance::photo_coupling(int lam_i)
 {
-  // A_1/2 or A_3/2 depending on ratio R_photo
-  double a;
-  (std::abs(lam_i) == 1) ? (a = R_photo) : (a = sqrt(1. - R_photo * R_photo));
+    // For spin-1/2 exchange no double flip
+    if (J == 1 && abs(lam_i) > 1) return 0.;
 
-  // Electromagnetic decay width given by VMD assumption
-  std::complex<double> emGamma = (xBR * gamRes) * pow(fJpsi / mJpsi, 2.);
-  emGamma *= pow(xr * pi_bar / pf_bar, double(2 * l_min + 1)) * P_t;
+    // A_1/2 or A_3/2 depending on ratio R_photo
+    double a;
+    (std::abs(lam_i) == 1) ? (a = R_photo) : (a = sqrt(1. - R_photo * R_photo));
 
-  // Photo-coupling overall size of |A_1/2|^2 + |A_3/2|^2 is restriced from VMD
-  std::complex<double> A_lam = emGamma * M_PI * mRes * double(J + 1) / (2. * mPro * pi_bar * pi_bar);
-  A_lam = sqrt(xr * A_lam);
+    // Electromagnetic decay width given by VMD assumption
+    std::complex<double> emGamma = (xBR * gamRes) * pow(fJpsi / mJpsi, 2.);
+    emGamma *= pow(xr * pi_bar / pf_bar, double(2 * l_min + 1)) * P_t;
 
-  std::complex<double> result = sqrt(xr * s) * pi_bar / mRes;
-  result *= sqrt(xr * 8. * mPro * mRes / kinematics->initial->momentum(s));
-  result *= A_lam * a;
+    // Photo-coupling overall size of |A_1/2|^2 + |A_3/2|^2 is restriced from VMD
+    std::complex<double> A_lam = emGamma * M_PI * mRes * double(J + 1) / (2. * mPro * pi_bar * pi_bar);
+    A_lam = sqrt(xr * A_lam);
 
-  // FACTPR PF 4 PI SOMETIMES FACTORED OUT
-  result *= sqrt(4. * M_PI * M_ALPHA);
+    std::complex<double> result = sqrt(xr * s) * pi_bar / mRes;
+    result *= sqrt(xr * 8. * mPro * mRes / kinematics->initial->momentum(s));
+    result *= A_lam * a;
 
-  return result;
+    // FACTPR PF 4 PI SOMETIMES FACTORED OUT
+    result *= sqrt(4. * M_PI * M_ALPHA);
+
+    return result;
 };
 
 // Hadronic decay helicity amplitude for the R -> J/psi p process
 std::complex<double> jpacPhoto::baryon_resonance::hadronic_coupling(int lam_f)
 {
-  // Hadronic coupling constant g, given in terms of branching ratio xBR
-  std::complex<double> g;
-  g  = 8. * M_PI * xBR * gamRes;
-  g *=  mRes * mRes * double(J + 1) / 6.;
-  g /= pow(pf_bar, double(2 * l_min + 1));
-  g = sqrt(xr * g);
+    // Hadronic coupling constant g, given in terms of branching ratio xBR
+    std::complex<double> g;
+    g  = 8. * M_PI * xBR * gamRes;
+    g *=  mRes * mRes * double(J + 1) / 6.;
+    g /= pow(pf_bar, double(2 * l_min + 1));
+    g = sqrt(xr * g);
 
-  std::complex<double> gpsi;
-  gpsi = g * pow(kinematics->final->momentum(s), l_min);
+    std::complex<double> gpsi;
+    gpsi = g * pow(kinematics->final->momentum(s), l_min);
 
-  return gpsi;
+    return gpsi;
 };

--- a/src/amplitudes/dirac_exchange.cpp
+++ b/src/amplitudes/dirac_exchange.cpp
@@ -9,7 +9,7 @@
 
 //------------------------------------------------------------------------------
 // Combine everything and contract indices
-std::complex<double> jpacPhoto::dirac_exchange::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::dirac_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];

--- a/src/amplitudes/dirac_exchange.cpp
+++ b/src/amplitudes/dirac_exchange.cpp
@@ -11,29 +11,29 @@
 // Combine everything and contract indices
 std::complex<double> jpacPhoto::dirac_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  // Store the invariant energies to avoid having to pass them around 
-  s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
+    // Store the invariant energies to avoid having to pass them around 
+    s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
 
-  std::complex<double> result = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    std::complex<double> result = 0.;
+    for (int i = 0; i < 4; i++)
     {
-      std::complex<double> temp;
-      temp  = top_vertex(i, lam_gam, lam_rec);
-      temp *= dirac_propagator(i, j);
-      temp *= bottom_vertex(j, lam_vec, lam_targ);
+        for (int j = 0; j < 4; j++)
+        {
+            std::complex<double> temp;
+            temp  = top_vertex(i, lam_gam, lam_rec);
+            temp *= dirac_propagator(i, j);
+            temp *= bottom_vertex(j, lam_vec, lam_targ);
 
-      result += temp;
+            result += temp;
+        }
     }
-  }
 
-  return result;
+    return result;
 };
 
 
@@ -42,23 +42,23 @@ std::complex<double> jpacPhoto::dirac_exchange::helicity_amplitude(std::array<in
 // (ubar epsilon-slashed)
 std::complex<double> jpacPhoto::dirac_exchange::top_vertex(int i, int lam_gam, int lam_rec)
 {
-  if (ScTOP == true)
-  {
-    // Scalar for testing purposes
-    return gGam * kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI);
-  }
+    if (ScTOP == true)
+    {
+        // Scalar for testing purposes
+        return gGam * kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI);
+    }
 
-  std::complex<double> result = 0.;
-  for (int k = 0; k < 4; k++)
-  {
-    std::complex<double> temp;
-    temp  = kinematics->recoil->adjoint_component(k, lam_rec, s, theta + M_PI); // theta_recoil = theta + pi
-    temp *= slashed_eps(k, i, lam_gam, kinematics->eps_gamma, false, s, 1.); // theta_gamma = 0
+    std::complex<double> result = 0.;
+    for (int k = 0; k < 4; k++)
+    {
+        std::complex<double> temp;
+        temp  = kinematics->recoil->adjoint_component(k, lam_rec, s, theta + M_PI); // theta_recoil = theta + pi
+        temp *= slashed_eps(k, i, lam_gam, kinematics->eps_gamma, false, s, 1.); // theta_gamma = 0
 
-    result += temp;
-  }
+        result += temp;
+    }
 
-  return gGam * result;
+    return gGam * result;
 };
 
 //------------------------------------------------------------------------------
@@ -66,23 +66,23 @@ std::complex<double> jpacPhoto::dirac_exchange::top_vertex(int i, int lam_gam, i
 // (epsilon*-slashed u)
 std::complex<double> jpacPhoto::dirac_exchange::bottom_vertex(int j, int lam_vec, int lam_targ)
 {
-  if (ScBOT == true)
-  {
-    // Scalar for testing purposes
-    return gVec * kinematics->target->component(j, lam_targ, s , M_PI); // theta_targer = pi
-  }
+    if (ScBOT == true)
+    {
+        // Scalar for testing purposes
+        return gVec * kinematics->target->component(j, lam_targ, s , M_PI); // theta_targer = pi
+    }
 
-  std::complex<double> result = 0.;
-  for (int k = 0; k < 4; k++)
-  {
-    std::complex<double> temp;
-    temp  = slashed_eps(j, k, lam_vec, kinematics->eps_vec, true, s, theta); //theta_vec = theta
-    temp *= kinematics->target->component(k, lam_targ, s , M_PI); // theta_target = pi
+    std::complex<double> result = 0.;
+    for (int k = 0; k < 4; k++)
+    {
+        std::complex<double> temp;
+        temp  = slashed_eps(j, k, lam_vec, kinematics->eps_vec, true, s, theta); //theta_vec = theta
+        temp *= kinematics->target->component(k, lam_targ, s , M_PI); // theta_target = pi
 
-    result += temp;
-  }
+        result += temp;
+    }
 
-  return gVec * result;
+    return gVec * result;
 };
 
 //------------------------------------------------------------------------------
@@ -91,79 +91,80 @@ double jpacPhoto::dirac_exchange::exchange_mass()
     double result = 0.;
     for (int mu = 0; mu < 4; mu++)
     {
-      std::complex<double> temp;
-      temp  = exchange_momentum(mu);
-      temp *= metric[mu];
-      temp *= exchange_momentum(mu);
+        std::complex<double> temp;
+        temp  = exchange_momentum(mu);
+        temp *= metric[mu];
+        temp *= exchange_momentum(mu);
 
-      result += real(temp);
+        result += real(temp);
     }
+
     return result;
 }
 
 std::complex<double> jpacPhoto::dirac_exchange::exchange_momentum(int mu)
 {
-  std::complex<double> qGamma_mu, qRec_mu;
-  qGamma_mu   = kinematics->initial->q(mu, s, M_PI);
-  qRec_mu     = kinematics->final->p(mu, s, theta + M_PI);
+    std::complex<double> qGamma_mu, qRec_mu;
+    qGamma_mu   = kinematics->initial->q(mu, s, M_PI);
+    qRec_mu     = kinematics->final->p(mu, s, theta + M_PI);
 
-  return qRec_mu - qGamma_mu;
+    return qRec_mu - qGamma_mu;
 };
 
 std::complex<double> jpacPhoto::dirac_exchange::slashed_exchange_momentum(int i, int j)
 {
-  std::complex<double> result = 0.;
-  for (int mu = 0; mu < 4; mu++)
-  {
-    std::complex<double> temp;
-    temp  = gamma_matrices[mu][i][j];
-    temp *= metric[mu];
-    temp *= exchange_momentum(mu);
+    std::complex<double> result = 0.;
+    for (int mu = 0; mu < 4; mu++)
+    {
+        std::complex<double> temp;
+        temp  = gamma_matrices[mu][i][j];
+        temp *= metric[mu];
+        temp *= exchange_momentum(mu);
 
-    result += temp;
-  }
+        result += temp;
+    }
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Slashed polarization vectors
 std::complex<double> jpacPhoto::dirac_exchange::slashed_eps(int i, int j, double lam, polarization_vector * eps, bool STAR, double s, double theta)
 {
-  std::complex<double> result = 0.;
-  for (int mu = 0; mu < 4; mu++)
-  {
-    std::complex<double> temp;
-    if (STAR == false)
+    std::complex<double> result = 0.;
+    for (int mu = 0; mu < 4; mu++)
     {
-      temp  = eps->component(mu, lam, s, theta);
-    }
-    else
-    {
-      temp = eps->conjugate_component(mu, lam, s, theta);
-    }
-    temp *= metric[mu];
-    temp *= gamma_matrices[mu][i][j];
+        std::complex<double> temp;
+        if (STAR == false)
+        {
+            temp  = eps->component(mu, lam, s, theta);
+        }
+        else
+        {
+            temp = eps->conjugate_component(mu, lam, s, theta);
+        }
+        temp *= metric[mu];
+        temp *= gamma_matrices[mu][i][j];
 
-    result += temp;
-  }
+        result += temp;
+    }
 
-  return result;
+    return result;
 };
 
 
 //------------------------------------------------------------------------------
 std::complex<double> jpacPhoto::dirac_exchange::dirac_propagator(int i, int j)
 {
-  std::complex<double> result;
-  result = slashed_exchange_momentum(i, j);
+    std::complex<double> result;
+    result = slashed_exchange_momentum(i, j);
 
-  if (i == j)
-  {
-    result += mEx;
-  }
+    if (i == j)
+    {
+        result += mEx;
+    }
 
-  result /= exchange_mass() - mEx2;
+    result /= exchange_mass() - mEx2;
 
-  return result;
+    return result;
 };

--- a/src/amplitudes/observables.cpp
+++ b/src/amplitudes/observables.cpp
@@ -23,7 +23,6 @@ void jpacPhoto::amplitude::check_cache(double _s, double _t)
     else // save a new set
     {
         cached_helicity_amplitude.clear();
-
         for (int i = 0; i < kinematics->nAmps; i++)
         {
             cached_helicity_amplitude.push_back(helicity_amplitude(kinematics->helicities[i], _s, _t));
@@ -226,8 +225,8 @@ std::complex<double> jpacPhoto::amplitude::SDME(int alpha, int lam, int lamp, do
 };
 
 // ---------------------------------------------------------------------------
-// Beam asymmetry along y axis sigma_y 
-double jpacPhoto::amplitude::beam_asymmetry_y(double s, double t)
+// Integrated beam asymmetry sigma_4pi
+double jpacPhoto::amplitude::beam_asymmetry_4pi(double s, double t)
 {
     double rho100 = real(SDME(1, 0, 0, s, t));
     double rho111 = real(SDME(1, 1, 1, s, t));
@@ -237,8 +236,8 @@ double jpacPhoto::amplitude::beam_asymmetry_y(double s, double t)
     return -(rho100 + 2. * rho111) / (rho000 + 2. * rho011);
 };
 // ---------------------------------------------------------------------------
-// Integrated beam asymmetry sigma_4pi
-double jpacPhoto::amplitude::beam_asymmetry_4pi(double s, double t)
+// Beam asymmetry along y axis sigma_y 
+double jpacPhoto::amplitude::beam_asymmetry_y(double s, double t)
 {
     double rho111  = real(SDME(1, 1,  1, s, t));
     double rho11m1 = real(SDME(1, 1, -1, s, t));

--- a/src/amplitudes/observables.cpp
+++ b/src/amplitudes/observables.cpp
@@ -15,7 +15,7 @@ void jpacPhoto::amplitude::check_cache(double _s, double _t)
   // check if saved version its the one we want
   if (  (abs(cached_s - _s) < 0.00001) && 
         (abs(cached_t - _t) < 0.00001) &&
-         (abs(cached_mVec2 - kinematics->mVec2) < 0.00001) // important to make sure the value of mVec hasnt chanced since last time
+        (abs(cached_mX2 - kinematics->mX2) < 0.00001) // important to make sure the value of mX2 hasnt chanced since last time
      )
   {
     return; // do nothing
@@ -28,7 +28,7 @@ void jpacPhoto::amplitude::check_cache(double _s, double _t)
     }
 
     // update cache info
-    cached_mVec2 = kinematics->mVec2; cached_s = _s; cached_t = _t;
+    cached_mX2 = kinematics->mX2; cached_s = _s; cached_t = _t;
   }
 
   return;

--- a/src/amplitudes/observables.cpp
+++ b/src/amplitudes/observables.cpp
@@ -22,10 +22,12 @@ void jpacPhoto::amplitude::check_cache(double _s, double _t)
   }
   else // save a new set
   {
-    for (int i = 0; i < 24; i++)
+    cached_helicity_amplitude.clear();
+
+    for (int i = 0; i < kinematics->nAmps; i++)
     {
-      cached_helicity_amplitude[i] = helicity_amplitude(kinematics->helicities[i], _s, _t);
-    }
+        cached_helicity_amplitude.push_back(helicity_amplitude(kinematics->helicities[i], _s, _t));
+    };
 
     // update cache info
     cached_mX2 = kinematics->mX2; cached_s = _s; cached_t = _t;
@@ -42,7 +44,7 @@ double jpacPhoto::amplitude::probability_distribution(double s, double t)
   check_cache(s, t);
 
   double sum = 0.;
-  for (int i = 0; i < 24; i++)
+  for (int i = 0; i < kinematics->nAmps; i++)
   {
     std::complex<double> amp_i = cached_helicity_amplitude[i];
     sum += std::real(amp_i * conj(amp_i));

--- a/src/amplitudes/observables.cpp
+++ b/src/amplitudes/observables.cpp
@@ -12,45 +12,45 @@
 
 void jpacPhoto::amplitude::check_cache(double _s, double _t)
 {
-  // check if saved version its the one we want
-  if (  (abs(cached_s - _s) < 0.00001) && 
-        (abs(cached_t - _t) < 0.00001) &&
-        (abs(cached_mX2 - kinematics->mX2) < 0.00001) // important to make sure the value of mX2 hasnt chanced since last time
-     )
-  {
-    return; // do nothing
-  }
-  else // save a new set
-  {
-    cached_helicity_amplitude.clear();
-
-    for (int i = 0; i < kinematics->nAmps; i++)
+    // check if saved version its the one we want
+    if (  (abs(cached_s - _s) < 0.00001) && 
+          (abs(cached_t - _t) < 0.00001) &&
+          (abs(cached_mX2 - kinematics->mX2) < 0.00001) // important to make sure the value of mX2 hasnt chanced since last time
+       )
     {
-        cached_helicity_amplitude.push_back(helicity_amplitude(kinematics->helicities[i], _s, _t));
-    };
+        return; // do nothing
+    }
+    else // save a new set
+    {
+        cached_helicity_amplitude.clear();
 
-    // update cache info
-    cached_mX2 = kinematics->mX2; cached_s = _s; cached_t = _t;
-  }
+        for (int i = 0; i < kinematics->nAmps; i++)
+        {
+            cached_helicity_amplitude.push_back(helicity_amplitude(kinematics->helicities[i], _s, _t));
+        };
 
-  return;
+        // update cache info
+        cached_mX2 = kinematics->mX2; cached_s = _s; cached_t = _t;
+    }
+
+    return;
 };
 
 // ---------------------------------------------------------------------------
 // Square of the spin averaged amplitude squared
 double jpacPhoto::amplitude::probability_distribution(double s, double t)
 {
-  // Check we have the right amplitudes cached
-  check_cache(s, t);
+    // Check we have the right amplitudes cached
+    check_cache(s, t);
 
-  double sum = 0.;
-  for (int i = 0; i < kinematics->nAmps; i++)
-  {
-    std::complex<double> amp_i = cached_helicity_amplitude[i];
-    sum += std::real(amp_i * conj(amp_i));
-  }
+    double sum = 0.;
+    for (int i = 0; i < kinematics->nAmps; i++)
+    {
+        std::complex<double> amp_i = cached_helicity_amplitude[i];
+        sum += std::real(amp_i * conj(amp_i));
+    }
 
-  return sum;
+    return sum;
 };
 
 // ---------------------------------------------------------------------------
@@ -58,15 +58,15 @@ double jpacPhoto::amplitude::probability_distribution(double s, double t)
 // in NANOBARN
 double jpacPhoto::amplitude::differential_xsection(double s, double t)
 {
-  double sum = probability_distribution(s, t);
+    double sum = probability_distribution(s, t);
 
-  double norm = 1.;
-  norm /= 64. * M_PI * s;
-  norm /= real(pow(kinematics->initial->momentum(s), 2.));
-  norm /= (2.56819E-6); // Convert from GeV^-2 -> nb
-  norm /= 4.; // Average over initial state helicites
+    double norm = 1.;
+    norm /= 64. * M_PI * s;
+    norm /= real(pow(kinematics->initial->momentum(s), 2.));
+    norm /= (2.56819E-6); // Convert from GeV^-2 -> nb
+    norm /= 4.; // Average over initial state helicites
 
-  return norm * sum;
+    return norm * sum;
 };
 
 // ---------------------------------------------------------------------------
@@ -74,186 +74,186 @@ double jpacPhoto::amplitude::differential_xsection(double s, double t)
 // IN NANOBARN
 double jpacPhoto::amplitude::integrated_xsection(double s)
 {
-  auto F = [&](double t)
-  {
-    return differential_xsection(s, t);
-  };
+    auto F = [&](double t)
+    {
+        return differential_xsection(s, t);
+    };
 
-  ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
-  ROOT::Math::Functor1D wF(F);
-  ig.SetFunction(wF);
+    ROOT::Math::GSLIntegrator ig(ROOT::Math::IntegrationOneDim::kADAPTIVE, ROOT::Math::Integration::kGAUSS61);
+    ROOT::Math::Functor1D wF(F);
+    ig.SetFunction(wF);
 
-  double t_min = kinematics->t_man(s, 0.);
-  double t_max = kinematics->t_man(s, M_PI);
+    double t_min = kinematics->t_man(s, 0.);
+    double t_max = kinematics->t_man(s, M_PI);
 
-  return ig.Integral(t_max, t_min);
+    return ig.Integral(t_max, t_min);
 };
 
 // ---------------------------------------------------------------------------
 // Polarizatiopn asymmetry between beam and recoil proton
 double jpacPhoto::amplitude::K_LL(double s, double t)
 {
-  // Check we have the right amplitudes cached
-  check_cache(s, t);
-  
-  double sigmapp = 0., sigmapm = 0.;
-  for (int i = 0; i < 6; i++)
-  {
-    std::complex<double> squarepp, squarepm;
+    // Check we have the right amplitudes cached
+    check_cache(s, t);
 
-    // Amplitudes with lam_gam = + and lam_recoil = +
-    squarepp = cached_helicity_amplitude[2*i+1];
-    squarepp *= conj(squarepp);
-    sigmapp += real(squarepp);
+    double sigmapp = 0., sigmapm = 0.;
+    for (int i = 0; i < 6; i++)
+    {
+        std::complex<double> squarepp, squarepm;
 
-    // Amplitudes with lam_gam = + and lam_recoil = -
-    squarepm = cached_helicity_amplitude[2*i];
-    squarepm *= conj(squarepm);
-    sigmapm += real(squarepm);
-  }
+        // Amplitudes with lam_gam = + and lam_recoil = +
+        squarepp = cached_helicity_amplitude[2*i+1];
+        squarepp *= conj(squarepp);
+        sigmapp += real(squarepp);
 
-  return (sigmapp - sigmapm) / (sigmapp + sigmapm);
+        // Amplitudes with lam_gam = + and lam_recoil = -
+        squarepm = cached_helicity_amplitude[2*i];
+        squarepm *= conj(squarepm);
+        sigmapm += real(squarepm);
+    }
+
+    return (sigmapp - sigmapm) / (sigmapp + sigmapm);
 }
 
 // ---------------------------------------------------------------------------
 // Polarization asymmetry between beam and target proton
 double jpacPhoto::amplitude::A_LL(double s, double t)
 {
-  // Check we have the right amplitudes cached
-  check_cache(s, t);
-  
-  double sigmapp = 0., sigmapm = 0.;
-  for (int i = 0; i < 6; i++)
-  {
-    std::complex<double> squarepp, squarepm;
+    // Check we have the right amplitudes cached
+    check_cache(s, t);
 
-    // Amplitudes with lam_gam = + and lam_targ = +
-    squarepp = cached_helicity_amplitude[i+6];
-    squarepp *= conj(squarepp);
-    sigmapp += real(squarepp);
+    double sigmapp = 0., sigmapm = 0.;
+    for (int i = 0; i < 6; i++)
+    {
+        std::complex<double> squarepp, squarepm;
 
-    // Amplitudes with lam_gam = + and lam_targ = -
-    squarepm = cached_helicity_amplitude[i];
-    squarepm *= conj(squarepm);
-    sigmapm += real(squarepm);
-  }
+        // Amplitudes with lam_gam = + and lam_targ = +
+        squarepp = cached_helicity_amplitude[i+6];
+        squarepp *= conj(squarepp);
+        sigmapp += real(squarepp);
 
-  return (sigmapp - sigmapm) / (sigmapp + sigmapm);
+        // Amplitudes with lam_gam = + and lam_targ = -
+        squarepm = cached_helicity_amplitude[i];
+        squarepm *= conj(squarepm);
+        sigmapm += real(squarepm);
+    }
+
+    return (sigmapp - sigmapm) / (sigmapp + sigmapm);
 }
 
 // ---------------------------------------------------------------------------
 // Photon spin-density matrix elements
 std::complex<double> jpacPhoto::amplitude::SDME(int alpha, int lam, int lamp, double s, double t)
 {
-  if (alpha < 0 || alpha > 2 || std::abs(lam) > 1 || std::abs(lamp) > 1)
-  {
-    std::cout << "\nError! Invalid parameter passed to SDME. Returning 0!\n";
-    return 0.;
-  };
-
-  // Phase and whether to conjugate at the end
-  bool CONJ = false;
-  double phase = 1.;
-
-  // if first index smaller, switch them
-  if (std::abs(lam) < std::abs(lamp))
-  {
-    int temp = lam;
-    lam = lamp;
-    lamp = temp;
-
-    CONJ = true;
-  }
-
-  // if first index is negative, flip to positive
-  if (lam < 0)
-  {
-    lam *= -1;
-    lamp *= -1;
-
-    phase *= pow(-1., double(lam - lamp));
-  }
-
-  // Normalization (sum over all amplitudes squared)
-  double norm = probability_distribution(s, t);
-
-  // These are the indexes of the amplitudes in reaction_kinematics that have
-  // lambda_V = +1
-  std::vector<int> pos_iters = {0, 1, 6, 7, 12, 13, 18, 19};
-  std::vector<int> neg_iters = {12, 13, 18, 19, 0, 1, 6, 7};
-
-  // j and k filter the right helicity combinations for 00, 1-1, 10, 11
-  int j, k;
-  (lam == 0) ? (k = 2) : (k = 0);
-
-  switch (lamp)
-  {
-    case -1: { j = 4; break; }
-    case 0:  { j = 2; break; }
-    case 1:  { j = 0; break; }
-    default:
+    if (alpha < 0 || alpha > 2 || std::abs(lam) > 1 || std::abs(lamp) > 1)
     {
-     std::cout << "\nSDME: Invalid parameter. J/Psi helicity projection lamp = 0 or 1! Returning zero.";
-     return 0.;;
+        std::cout << "\nError! Invalid parameter passed to SDME. Returning 0!\n";
+        return 0.;
+    };
+
+    // Phase and whether to conjugate at the end
+    bool CONJ = false;
+    double phase = 1.;
+
+    // if first index smaller, switch them
+    if (std::abs(lam) < std::abs(lamp))
+    {
+        int temp = lam;
+        lam = lamp;
+        lamp = temp;
+
+        CONJ = true;
     }
-  }
 
-  // Sum over the appropriate amplitude combinations
-  std::complex<double> result = 0.;
-  for (int i = 0; i < 8; i++)
-  {
-    int index;
-    (alpha == 0) ? (index = pos_iters[i]) : (index = neg_iters[i]);
+    // if first index is negative, flip to positive
+    if (lam < 0)
+    {
+        lam *= -1;
+        lamp *= -1;
 
-    std::complex<double> amp_i, amp_j;
-    amp_i = cached_helicity_amplitude[index + k];
-    amp_j = cached_helicity_amplitude[pos_iters[i] + j];
+        phase *= pow(-1., double(lam - lamp));
+    }
 
-    (alpha == 2) ? (amp_j *= xi * double(kinematics->helicities[pos_iters[i] + j][0])) : (amp_j *= xr);
+    // Normalization (sum over all amplitudes squared)
+    double norm = probability_distribution(s, t);
 
-    result += real(amp_i * conj(amp_j));
-  }
+    // These are the indexes of the amplitudes in reaction_kinematics that have
+    // lambda_V = +1
+    std::vector<int> pos_iters = {0, 1, 6, 7, 12, 13, 18, 19};
+    std::vector<int> neg_iters = {12, 13, 18, 19, 0, 1, 6, 7};
 
-  if (CONJ == true)
-  {
-    result = conj(result);
-  }
+    // j and k filter the right helicity combinations for 00, 1-1, 10, 11
+    int j, k;
+    (lam == 0) ? (k = 2) : (k = 0);
 
-  result /= norm;
-  result *= phase;
+    switch (lamp)
+    {
+        case -1: { j = 4; break; }
+        case 0:  { j = 2; break; }
+        case 1:  { j = 0; break; }
+        default:
+        {
+            std::cout << "\nSDME: Invalid parameter. J/Psi helicity projection lamp = 0 or 1! Returning zero.";
+            return 0.;;
+        }
+    }
 
-  return result;
+    // Sum over the appropriate amplitude combinations
+    std::complex<double> result = 0.;
+    for (int i = 0; i < 8; i++)
+    {
+        int index;
+        (alpha == 0) ? (index = pos_iters[i]) : (index = neg_iters[i]);
+
+        std::complex<double> amp_i, amp_j;
+        amp_i = cached_helicity_amplitude[index + k];
+        amp_j = cached_helicity_amplitude[pos_iters[i] + j];
+
+        (alpha == 2) ? (amp_j *= xi * double(kinematics->helicities[pos_iters[i] + j][0])) : (amp_j *= xr);
+
+        result += real(amp_i * conj(amp_j));
+    }
+
+    if (CONJ == true)
+    {
+        result = conj(result);
+    }
+
+    result /= norm;
+    result *= phase;
+
+    return result;
 };
 
 // ---------------------------------------------------------------------------
 // Beam asymmetry along y axis sigma_y 
 double jpacPhoto::amplitude::beam_asymmetry_y(double s, double t)
 {
-  double rho100 = real(SDME(1, 0, 0, s, t));
-  double rho111 = real(SDME(1, 1, 1, s, t));
-  double rho000 = real(SDME(0, 0, 0, s, t));
-  double rho011 = real(SDME(0, 1, 1, s, t));
+    double rho100 = real(SDME(1, 0, 0, s, t));
+    double rho111 = real(SDME(1, 1, 1, s, t));
+    double rho000 = real(SDME(0, 0, 0, s, t));
+    double rho011 = real(SDME(0, 1, 1, s, t));
 
-  return -(rho100 + 2. * rho111) / (rho000 + 2. * rho011);
+    return -(rho100 + 2. * rho111) / (rho000 + 2. * rho011);
 };
 // ---------------------------------------------------------------------------
 // Integrated beam asymmetry sigma_4pi
 double jpacPhoto::amplitude::beam_asymmetry_4pi(double s, double t)
 {
-  double rho111  = real(SDME(1, 1,  1, s, t));
-  double rho11m1 = real(SDME(1, 1, -1, s, t));
-  double rho011  = real(SDME(0, 1,  1, s, t));
-  double rho01m1 = real(SDME(0, 1, -1, s, t));
+    double rho111  = real(SDME(1, 1,  1, s, t));
+    double rho11m1 = real(SDME(1, 1, -1, s, t));
+    double rho011  = real(SDME(0, 1,  1, s, t));
+    double rho01m1 = real(SDME(0, 1, -1, s, t));
 
-  return (rho111 + rho11m1) / (rho011 + rho01m1);
+    return (rho111 + rho11m1) / (rho011 + rho01m1);
 };
 
 // ---------------------------------------------------------------------------
 // Parity asymmetry P_sigma
 double jpacPhoto::amplitude::parity_asymmetry(double s, double t)
 {
-  double rho100  = real(SDME(1, 0,  0, s, t));
-  double rho11m1 = real(SDME(1, 1, -1, s, t));
+    double rho100  = real(SDME(1, 0,  0, s, t));
+    double rho11m1 = real(SDME(1, 1, -1, s, t));
 
-  return 2. * rho11m1 - rho100;
+    return 2. * rho11m1 - rho100;
 };

--- a/src/amplitudes/pomeron_exchange.cpp
+++ b/src/amplitudes/pomeron_exchange.cpp
@@ -22,16 +22,17 @@ std::complex<double> jpacPhoto::pomeron_exchange::helicity_amplitude(std::array<
     std::complex<double> result = 0.;
 
     // IF using helicity conserving delta fuction model
-    if (DELTA == true)
+    if (model == 1)
     {
         (lam_gam == lam_vec && lam_rec == lam_targ) ? (result = regge_factor()) : (result = 0.);
         return result;
     }
 
-    // else use Lesniak-Szczepaniak Model
+    // else contract indices
     for (int mu = 0; mu < 4; mu++)
     {
-        std::complex<double> temp = regge_factor();
+        std::complex<double> temp = 1.;
+        temp *= regge_factor();
         temp *= top_vertex(mu, lam_gam, lam_vec);
         temp *= metric[mu];
         temp *= bottom_vertex(mu, lam_targ, lam_rec);
@@ -75,23 +76,54 @@ std::complex<double> jpacPhoto::pomeron_exchange::bottom_vertex(int mu, int lam_
 // Top vertex coupling the photon, pomeron, and vector meson.
 std::complex<double> jpacPhoto::pomeron_exchange::top_vertex(int mu, int lam_gam, int lam_vec)
 {
-    std::complex<double> sum1 = 0., sum2 = 0.;
-    for (int nu = 0; nu < 4; nu++)
+    std::complex<double> result = 0.;
+
+    if (model == 0)
     {
-        std::complex<double> temp1, temp2;
+        std::complex<double> sum1 = 0., sum2 = 0.;
+        for (int nu = 0; nu < 4; nu++)
+        {
+            std::complex<double> temp1, temp2;
 
-        temp1 = kinematics->initial->q(nu, s, 0.);
-        temp1 *= metric[nu];
-        temp1 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
-        sum1 += kinematics->eps_gamma->component(mu, lam_gam, s, 0.) * temp1;
+            // (q . eps_vec^*) eps_gam^mu
+            temp1  = kinematics->initial->q(nu, s, 0.);
+            temp1 *= metric[nu];
+            temp1 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+            sum1  += kinematics->eps_gamma->component(mu, lam_gam, s, 0.) * temp1;
 
-        temp2 = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
-        temp2 *= metric[nu];
-        temp2 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
-        sum2 += kinematics->initial->q(mu, s, 0.) * temp2;
+            // (eps_vec^* . eps_gam) q^mu
+            temp2  = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
+            temp2 *= metric[nu];
+            temp2 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+            sum2  += kinematics->initial->q(mu, s, 0.) * temp2;
+        }
+
+        result = -sum1 + sum2;
     }
+    else if (model == 2)
+    {
+        std::complex<double> sum1 = 0., sum2 = 0.;
+        for (int nu = 0; nu < 4; nu++)
+        {
+            std::complex<double> temp1, temp2;
 
-    return -sum1 + sum2;
+            // -2 * (q . eps_vec^*) eps_gam^mu
+            temp1  = kinematics->initial->q(nu, s, 0.);
+            temp1 *= metric[nu];
+            temp1 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+            sum1  += -2. * kinematics->eps_gamma->component(mu, lam_gam, s, 0.) * temp1;
+
+            // (eps_vec . eps_gam) (q + q')^mu
+            temp2  = kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+            temp2 *= metric[nu];
+            temp2 *= kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
+            sum2  += (kinematics->initial->q(mu, s, 0.) + kinematics->final->q(mu, s, theta)) * temp2;
+        }
+
+        result = (sum1 + sum2) / 2.;
+    };
+
+    return result;
 };
 
 // ---------------------------------------------------------------------------
@@ -104,11 +136,37 @@ std::complex<double> jpacPhoto::pomeron_exchange::regge_factor()
         exit(0);
     }
 
-    double t_min = kinematics->t_man(s, 0.); // t_min = t(theta = 0)
+    std::complex<double> result = 0.;
+    
+    if ( model == 0 || model == 1)
+    {
+        double t_min = kinematics->t_man(s, 0.); // t_min = t(theta = 0)
+        result  = exp(b0 * (t - t_min));
+        result *= pow(s - kinematics->sth(), pomeron_traj->eval(t));
+        result *= xi * norm * e;
+    }
+    else if (model == 2)
+    {
+        double mX2 = kinematics->mX2;
+        double th  = pow((kinematics->mT + kinematics->mR), 2.);
 
-    std::complex<double> result = exp(b0 * (t - t_min));
-    result *= pow(s - kinematics->sth(), pomeron_traj->eval(t));
-    result *= xi * norm * e;
+        double beta_0 = 4.;         // Pomeron - light quark coupling
+        double beta_c = norm;       // Pomeron - charm quark coupling
+        double mu2 = b0 * b0;       // cutoff parameter 
+        double etaprime = std::real(pomeron_traj->slope());
+
+        std::complex<double> F_t;
+        F_t  = 3. * beta_0;
+        F_t *= (th - 2.8*t);
+        F_t /= (th - t) *  pow((1. - (t / 0.7)) , 2.);
+
+        std::complex<double> G_p = -xi;
+        G_p  *= pow(xr * etaprime * s, pomeron_traj->eval(t) - 1.);
+
+        result  = 8. * beta_c * mu2 * G_p * F_t;
+        result /= (mX2 - t) * (2.*mu2 + mX2 - t);
+        result *= 2.;
+    };
 
     return result;
 };

--- a/src/amplitudes/pomeron_exchange.cpp
+++ b/src/amplitudes/pomeron_exchange.cpp
@@ -9,7 +9,7 @@
 
 // ---------------------------------------------------------------------------
 // Given a set of helicities for each particle, assemble the helicity amplitude by contracting Lorentz indicies
-std::complex<double> jpacPhoto::pomeron_exchange::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::pomeron_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];

--- a/src/amplitudes/pomeron_exchange.cpp
+++ b/src/amplitudes/pomeron_exchange.cpp
@@ -1,6 +1,6 @@
 // Vector meson photoproduction dynamics proceeding through a pomeron exchange
 //
-// Author:       Daniel Winney (2019)
+// Author:       Daniel Winney (2020)
 // Affiliation:  Joint Physics Analysis Center (JPAC)
 // Email:        dwinney@iu.edu
 // ---------------------------------------------------------------------------
@@ -11,104 +11,104 @@
 // Given a set of helicities for each particle, assemble the helicity amplitude by contracting Lorentz indicies
 std::complex<double> jpacPhoto::pomeron_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  // Save energies 
-  s = xs; t = xt; theta = kinematics->theta_s(xs, xt);
+    // Save energies 
+    s = xs; t = xt; theta = kinematics->theta_s(xs, xt);
 
-  std::complex<double> result = 0.;
+    std::complex<double> result = 0.;
 
-  // IF using helicity conserving delta fuction model
-  if (DELTA == true)
-  {
-    (lam_gam == lam_vec && lam_rec == lam_targ) ? (result = regge_factor()) : (result = 0.);
+    // IF using helicity conserving delta fuction model
+    if (DELTA == true)
+    {
+        (lam_gam == lam_vec && lam_rec == lam_targ) ? (result = regge_factor()) : (result = 0.);
+        return result;
+    }
+
+    // else use Lesniak-Szczepaniak Model
+    for (int mu = 0; mu < 4; mu++)
+    {
+        std::complex<double> temp = regge_factor();
+        temp *= top_vertex(mu, lam_gam, lam_vec);
+        temp *= metric[mu];
+        temp *= bottom_vertex(mu, lam_targ, lam_rec);
+
+        result += temp;
+    }
+
     return result;
-  }
-
-  // else use Lesniak-Szczepaniak Model
-  for (int mu = 0; mu < 4; mu++)
-  {
-    std::complex<double> temp = regge_factor();
-    temp *= top_vertex(mu, lam_gam, lam_vec);
-    temp *= metric[mu];
-    temp *= bottom_vertex(mu, lam_targ, lam_rec);
-
-    result += temp;
-  }
-
-  return result;
 };
 
 // ---------------------------------------------------------------------------
 // Bottom vertex coupling the target and recoil proton spinors to the vector pomeron
 std::complex<double> jpacPhoto::pomeron_exchange::bottom_vertex(int mu, int lam_targ, int lam_rec)
 {
-  std::complex<double> result = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    std::complex<double> result = 0.;
+    for (int i = 0; i < 4; i++)
     {
-    std::complex<double> temp;
-    // Recoil oriented an angle theta + pi
-    temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI);
+        for (int j = 0; j < 4; j++)
+        {
+            std::complex<double> temp;
+            // Recoil oriented an angle theta + pi
+            temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI);
 
-    // vector coupling
-    temp *= gamma_matrices[mu][i][j];
+            // vector coupling
+            temp *= gamma_matrices[mu][i][j];
 
-    // target oriented in negative z direction
-    temp *= kinematics->target->component(j, lam_targ, s, M_PI);
+            // target oriented in negative z direction
+            temp *= kinematics->target->component(j, lam_targ, s, M_PI);
 
-    result += temp;
+            result += temp;
+        }
     }
-  }
 
-  // Divide by s to remove the energy dependence left over by the spinors
-  result /= s;
+    // Divide by s to remove the energy dependence left over by the spinors
+    result /= s;
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
 // Top vertex coupling the photon, pomeron, and vector meson.
 std::complex<double> jpacPhoto::pomeron_exchange::top_vertex(int mu, int lam_gam, int lam_vec)
 {
-  std::complex<double> sum1 = 0., sum2 = 0.;
-  for (int nu = 0; nu < 4; nu++)
-  {
-    std::complex<double> temp1, temp2;
+    std::complex<double> sum1 = 0., sum2 = 0.;
+    for (int nu = 0; nu < 4; nu++)
+    {
+        std::complex<double> temp1, temp2;
 
-    temp1 = kinematics->initial->q(nu, s, 0.);
-    temp1 *= metric[nu];
-    temp1 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
-    sum1 += kinematics->eps_gamma->component(mu, lam_gam, s, 0.) * temp1;
+        temp1 = kinematics->initial->q(nu, s, 0.);
+        temp1 *= metric[nu];
+        temp1 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+        sum1 += kinematics->eps_gamma->component(mu, lam_gam, s, 0.) * temp1;
 
-    temp2 = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
-    temp2 *= metric[nu];
-    temp2 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
-    sum2 += kinematics->initial->q(mu, s, 0.) * temp2;
-  }
+        temp2 = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
+        temp2 *= metric[nu];
+        temp2 *= kinematics->eps_vec->conjugate_component(nu, lam_vec, s, theta);
+        sum2 += kinematics->initial->q(mu, s, 0.) * temp2;
+    }
 
-  return -sum1 + sum2;
+    return -sum1 + sum2;
 };
 
 // ---------------------------------------------------------------------------
 // Usual Regge power law behavior, s^alpha(t) with an exponential fall from the forward direction
 std::complex<double> jpacPhoto::pomeron_exchange::regge_factor()
 {
-  if (s < kinematics->sth())
-  {
-    std::cout << " \n pomeron_exchange: Trying to evaluate below threshold (sqrt(s) = " << sqrt(s) << ")! Quitting... \n";
-    exit(0);
-  }
+    if (s < kinematics->sth())
+    {
+        std::cout << " \n pomeron_exchange: Trying to evaluate below threshold (sqrt(s) = " << sqrt(s) << ")! Quitting... \n";
+        exit(0);
+    }
 
-  double t_min = kinematics->t_man(s, 0.); // t_min = t(theta = 0)
+    double t_min = kinematics->t_man(s, 0.); // t_min = t(theta = 0)
 
-  std::complex<double> result = exp(b0 * (t - t_min));
-  result *= pow(s - kinematics->sth(), pomeron_traj->eval(t));
-  result *= xi * norm * e;
+    std::complex<double> result = exp(b0 * (t - t_min));
+    result *= pow(s - kinematics->sth(), pomeron_traj->eval(t));
+    result *= xi * norm * e;
 
-  return result;
+    return result;
 };

--- a/src/amplitudes/pseudoscalar_exchange.cpp
+++ b/src/amplitudes/pseudoscalar_exchange.cpp
@@ -12,7 +12,7 @@
 
 //------------------------------------------------------------------------------
 // Combine everything and contract indices
-std::complex<double> jpacPhoto::pseudoscalar_exchange::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::pseudoscalar_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];

--- a/src/amplitudes/pseudoscalar_exchange.cpp
+++ b/src/amplitudes/pseudoscalar_exchange.cpp
@@ -14,137 +14,137 @@
 // Combine everything and contract indices
 std::complex<double> jpacPhoto::pseudoscalar_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  // Store the invariant energies to avoid having to pass them around 
-  s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
+    // Store the invariant energies to avoid having to pass them around 
+    s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
 
-  std::complex<double> result;
+    std::complex<double> result;
 
-  if (FOUR_VECS == true)
-  {
-    // Because its a scalar exchange we dont have any loose indices to contract
-    result  = top_vertex(lam_gam, lam_vec);
-    result *= scalar_propagator();
-    result *= bottom_vertex(lam_targ, lam_rec);
-  }
-  else
-  {
-    if (lam_vec != lam_gam || lam_targ != lam_rec) 
+    if (FOUR_VECS == true)
     {
-      return 0.; 
+        // Because its a scalar exchange we dont have any loose indices to contract
+        result  = top_vertex(lam_gam, lam_vec);
+        result *= scalar_propagator();
+        result *= bottom_vertex(lam_targ, lam_rec);
     }
     else
     {
-      result  = sqrt(2.) * gNN;
-      result *= gGamma / kinematics->mX;
-      result *= sqrt(xr * t) / 2.;
-      result *= (kinematics->mX2 - t);
-      result *= scalar_propagator();
+        if (lam_vec != lam_gam || lam_targ != lam_rec) 
+        {
+            return 0.; 
+        }
+        else
+        {
+            result  = sqrt(2.) * gNN;
+            result *= gGamma / kinematics->mX;
+            result *= sqrt(xr * t) / 2.;
+            result *= (kinematics->mX2 - t);
+            result *= scalar_propagator();
+        }
     }
-  }
 
-  // Multiply by the optional expontial form factor
-  if (IF_FF == true)
-  {
-    double tprime = t - kinematics->t_man(s, 0.);
-    result *= exp(b * tprime);
-  }
-  
-  return result;
+    // Multiply by the optional expontial form factor
+    if (IF_FF == true)
+    {
+        double tprime = t - kinematics->t_man(s, 0.);
+        result *= exp(b * tprime);
+    }
+
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Nucleon vertex
 std::complex<double> jpacPhoto::pseudoscalar_exchange::bottom_vertex(double lam_targ, double lam_rec)
 {
-  std::complex<double> result = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    std::complex<double> result = 0.;
+    for (int i = 0; i < 4; i++)
     {
-      // ubar(recoil) * gamma_5 * u(target)
-      std::complex<double> temp;
-      temp  = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_recoil = theta + pi
-      temp *= gamma_5[i][j];
-      temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_target = pi
+        for (int j = 0; j < 4; j++)
+        {
+            // ubar(recoil) * gamma_5 * u(target)
+            std::complex<double> temp;
+            temp  = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_recoil = theta + pi
+            temp *= gamma_5[i][j];
+            temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_target = pi
 
-      result += temp;
+            result += temp;
+        }
     }
-  }
 
-  // Sqrt(2) from isospin considering a charged pion field
-  // remove the Sqrt(2) if considering a neutral pion exchange
-  result *= sqrt(2.) * gNN;
+    // Sqrt(2) from isospin considering a charged pion field
+    // remove the Sqrt(2) if considering a neutral pion exchange
+    result *= sqrt(2.) * gNN;
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Photon vertex
 std::complex<double> jpacPhoto::pseudoscalar_exchange::top_vertex(double lam_gam, double lam_vec)
 {
-  std::complex<double> term1 = 0., term2 = 0.;
-  for (int mu = 0; mu < 4; mu++)
-  {
-    for (int nu = 0; nu < 4; nu++)
+    std::complex<double> term1 = 0., term2 = 0.;
+    for (int mu = 0; mu < 4; mu++)
     {
-      // (eps*_lam . eps_gam)(q_vec . q_gam)
-      std::complex<double> temp1;
-      temp1  = kinematics->eps_vec->conjugate_component(mu, lam_vec, s, theta);
-      temp1 *= metric[mu];
-      temp1 *= kinematics->eps_gamma->component(mu, lam_gam, s, 0.);
-      temp1 *= kinematics->initial->q(nu, s, 0.);
-      temp1 *= metric[nu];
-      temp1 *= kinematics->final->q(nu, s, theta);
+        for (int nu = 0; nu < 4; nu++)
+        {
+            // (eps*_lam . eps_gam)(q_vec . q_gam)
+            std::complex<double> temp1;
+            temp1  = kinematics->eps_vec->conjugate_component(mu, lam_vec, s, theta);
+            temp1 *= metric[mu];
+            temp1 *= kinematics->eps_gamma->component(mu, lam_gam, s, 0.);
+            temp1 *= kinematics->initial->q(nu, s, 0.);
+            temp1 *= metric[nu];
+            temp1 *= kinematics->final->q(nu, s, theta);
 
-      term1 += temp1;
+            term1 += temp1;
 
-      // (eps*_lam . q_gam)(eps_gam . q_vec)
-      std::complex<double> temp2;
-      temp2  = kinematics->eps_vec->conjugate_component(mu, lam_vec, s, theta);
-      temp2 *= metric[mu];
-      temp2 *= kinematics->initial->q(mu, s, 0.);
-      temp2 *= kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
-      temp2 *= metric[nu];
-      temp2 *= kinematics->final->q(nu, s, theta);
+            // (eps*_lam . q_gam)(eps_gam . q_vec)
+            std::complex<double> temp2;
+            temp2  = kinematics->eps_vec->conjugate_component(mu, lam_vec, s, theta);
+            temp2 *= metric[mu];
+            temp2 *= kinematics->initial->q(mu, s, 0.);
+            temp2 *= kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
+            temp2 *= metric[nu];
+            temp2 *= kinematics->final->q(nu, s, theta);
 
-      term2 += temp2;
+            term2 += temp2;
+        }
     }
-  }
 
-  std::complex<double> result;
-  result = term1 - term2;
+    std::complex<double> result;
+    result = term1 - term2;
 
-  // Coupling is normalized to the mass of the Axial vector particle
-  result *= gGamma / kinematics->mX;
+    // Coupling is normalized to the mass of the Axial vector particle
+    result *= gGamma / kinematics->mX;
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Simple pole propagator
 std::complex<double> jpacPhoto::pseudoscalar_exchange::scalar_propagator()
 {
-  if (REGGE == false)
-  {
-    return 1. / (t - mEx2);
-  }
-  else
-  {
-    std::complex<double> alpha_t = alpha->eval(t);
+    if (REGGE == false)
+    {
+        return 1. / (t - mEx2);
+    }
+    else
+    {
+        std::complex<double> alpha_t = alpha->eval(t);
 
-    if (std::abs(alpha_t) > 20.) return 0.;
+        if (std::abs(alpha_t) > 20.) return 0.;
 
-    // Else use the regge propagator
-    std::complex<double> result = 1.;
-    result  = - alpha->slope();
-    result *= 0.5 * (double(alpha->signature) +  exp(-xi * M_PI * alpha_t));
-    result *= cgamma(0. - alpha_t);
-    result *= pow(s, alpha_t);
-    return result;
-  }
+        // Else use the regge propagator
+        std::complex<double> result = 1.;
+        result  = - alpha->slope();
+        result *= 0.5 * (double(alpha->signature) +  exp(-xi * M_PI * alpha_t));
+        result *= cgamma(0. - alpha_t);
+        result *= pow(s, alpha_t);
+        return result;
+    }
 };

--- a/src/amplitudes/pseudoscalar_exchange.cpp
+++ b/src/amplitudes/pseudoscalar_exchange.cpp
@@ -40,9 +40,9 @@ std::complex<double> jpacPhoto::pseudoscalar_exchange::helicity_amplitude(std::v
     else
     {
       result  = sqrt(2.) * gNN;
-      result *= gGamma / kinematics->mVec;
+      result *= gGamma / kinematics->mX;
       result *= sqrt(xr * t) / 2.;
-      result *= (kinematics->mVec2 - t);
+      result *= (kinematics->mX2 - t);
       result *= scalar_propagator();
     }
   }
@@ -120,7 +120,7 @@ std::complex<double> jpacPhoto::pseudoscalar_exchange::top_vertex(double lam_gam
   result = term1 - term2;
 
   // Coupling is normalized to the mass of the Axial vector particle
-  result *= gGamma / kinematics->mVec;
+  result *= gGamma / kinematics->mX;
 
   return result;
 };

--- a/src/amplitudes/rarita_exchange.cpp
+++ b/src/amplitudes/rarita_exchange.cpp
@@ -9,7 +9,7 @@
 
 //------------------------------------------------------------------------------
 // Combine everything and contract indices
-std::complex<double> jpacPhoto::rarita_exchange::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::rarita_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];

--- a/src/amplitudes/rarita_exchange.cpp
+++ b/src/amplitudes/rarita_exchange.cpp
@@ -11,120 +11,120 @@
 // Combine everything and contract indices
 std::complex<double> jpacPhoto::rarita_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  // Store the invariant energies to avoid having to pass them around 
-  s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
+    // Store the invariant energies to avoid having to pass them around 
+    s = xs; t = xt, theta = kinematics->theta_s(xs, xt);
 
-  std::complex<double> result = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    std::complex<double> result = 0.;
+    for (int i = 0; i < 4; i++)
     {
-      std::complex<double> temp;
-      temp  = top_vertex(i, lam_gam, lam_rec);
-      temp *= rarita_propagator(i, j);
-      temp *= bottom_vertex(j, lam_vec, lam_targ);
+        for (int j = 0; j < 4; j++)
+        {
+            std::complex<double> temp;
+            temp  = top_vertex(i, lam_gam, lam_rec);
+            temp *= rarita_propagator(i, j);
+            temp *= bottom_vertex(j, lam_vec, lam_targ);
 
-      result += temp;
+            result += temp;
+        }
     }
-  }
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // rank-2 traceless tensor
 std::complex<double> jpacPhoto::rarita_exchange::g_bar(int mu, int nu)
 {
-  std::complex<double> result;
-  result = exchange_momentum(mu) * exchange_momentum(nu) / mEx2;
+    std::complex<double> result;
+    result = exchange_momentum(mu) * exchange_momentum(nu) / mEx2;
 
-  if (mu == nu)
-  {
-    result -= metric[mu];
-  }
+    if (mu == nu)
+    {
+        result -= metric[mu];
+    }
 
-  return result;
+    return result;
 };
 
 // g_bar contracted with gamma^nu
 std::complex<double> jpacPhoto::rarita_exchange::slashed_g_bar(int mu, int i, int j)
 {
-  std::complex<double> result = 0.;
+    std::complex<double> result = 0.;
 
-  for (int nu = 0; nu < 4; nu++)
-  {
-    std::complex<double> temp;
-    temp  = g_bar(mu, nu);
-    temp *= metric[nu];
-    temp *= gamma_matrices[nu][i][j];
+    for (int nu = 0; nu < 4; nu++)
+    {
+        std::complex<double> temp;
+        temp  = g_bar(mu, nu);
+        temp *= metric[nu];
+        temp *= gamma_matrices[nu][i][j];
 
-    result += temp;
-  }
+        result += temp;
+    }
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Relative momentum either entering (top vertex) or exiting (bottom vertex) the propagator
 std::complex<double> jpacPhoto::rarita_exchange::relative_momentum(int mu, std::string in_out)
 {
-  std::complex<double> q1_mu, q2_mu;
+    std::complex<double> q1_mu, q2_mu;
 
-  if ((in_out == "in") || (in_out == "top") || (in_out == "initial") )
-  {
-    q1_mu = kinematics->initial->q(mu, s, 0.);
-    q2_mu = kinematics->initial->p(mu, s, M_PI);
-  }
-  else if ((in_out == "out") || (in_out == "bot") || (in_out == "final"))
-  {
-    q1_mu = kinematics->final->q(mu, s, theta);
-    q2_mu = kinematics->final->p(mu, s, theta + M_PI);
-  }
-  else
-  {
-    std::cout << "Error! Unkown parameter: " << in_out << "passed to relative_momentum. ";
-    std::cout << "Quitting...";
-    exit(1);
-  }
+    if ((in_out == "in") || (in_out == "top") || (in_out == "initial") )
+    {
+        q1_mu = kinematics->initial->q(mu, s, 0.);
+        q2_mu = kinematics->initial->p(mu, s, M_PI);
+    }
+    else if ((in_out == "out") || (in_out == "bot") || (in_out == "final"))
+    {
+        q1_mu = kinematics->final->q(mu, s, theta);
+        q2_mu = kinematics->final->p(mu, s, theta + M_PI);
+    }
+    else
+    {
+        std::cout << "Error! Unkown parameter: " << in_out << "passed to relative_momentum. ";
+        std::cout << "Quitting...";
+        exit(1);
+    }
 
-  return q1_mu - q2_mu;
+    return q1_mu - q2_mu;
 }
 
 //------------------------------------------------------------------------------
 // Rarita-Schwinger Propagator
 std::complex<double> jpacPhoto::rarita_exchange::rarita_propagator(int i, int j)
 {
-  std::complex<double> result = 0.;
+    std::complex<double> result = 0.;
 
-  for (int mu = 0; mu < 4; mu++)
-  {
-    for(int nu = 0; nu < 4; nu++)
+    for (int mu = 0; mu < 4; mu++)
     {
-      std::complex<double> term_1;
-      term_1  = relative_momentum(mu, "in");
-      term_1 *= metric[mu];
-      term_1 *= g_bar(mu, nu);
-      term_1 *= metric[nu];
-      term_1 *= relative_momentum(nu, "out");
+        for(int nu = 0; nu < 4; nu++)
+        {
+            std::complex<double> term_1;
+            term_1  = relative_momentum(mu, "in");
+            term_1 *= metric[mu];
+            term_1 *= g_bar(mu, nu);
+            term_1 *= metric[nu];
+            term_1 *= relative_momentum(nu, "out");
 
-      std::complex<double> term_2;
-      term_2  = relative_momentum(mu, "in");
-      term_2 *= metric[mu];
-      term_2 *= slashed_g_bar(mu, i, j);
-      term_2 *= slashed_g_bar(nu, i, j);
-      term_2 *= metric[nu];
-      term_2 *= relative_momentum(nu, "out");
+            std::complex<double> term_2;
+            term_2  = relative_momentum(mu, "in");
+            term_2 *= metric[mu];
+            term_2 *= slashed_g_bar(mu, i, j);
+            term_2 *= slashed_g_bar(nu, i, j);
+            term_2 *= metric[nu];
+            term_2 *= relative_momentum(nu, "out");
 
-      result += -term_1 + term_2 / 3.;
-    }
-  }
+            result += -term_1 + term_2 / 3.;
+        }
+        }
 
-  result *= dirac_propagator(i, j);
+    result *= dirac_propagator(i, j);
 
-  return result;
+    return result;
 }

--- a/src/amplitudes/vector_exchange.cpp
+++ b/src/amplitudes/vector_exchange.cpp
@@ -9,7 +9,7 @@
 
 // ---------------------------------------------------------------------------
 // Assemble the helicity amplitude by contracting the lorentz indices
-std::complex<double> jpacPhoto::vector_exchange::helicity_amplitude(std::vector<int> helicities, double xs, double xt)
+std::complex<double> jpacPhoto::vector_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];
@@ -205,7 +205,7 @@ std::complex<double> jpacPhoto::vector_exchange::barrier_factor(int j, int M)
 // FEYNMAN EVALUATION
 // ---------------------------------------------------------------------------
 
-std::complex<double> jpacPhoto::vector_exchange::covariant_amplitude(std::vector<int> helicities)
+std::complex<double> jpacPhoto::vector_exchange::covariant_amplitude(std::array<int, 4> helicities)
 {
   int lam_gam = helicities[0];
   int lam_targ = helicities[1];

--- a/src/amplitudes/vector_exchange.cpp
+++ b/src/amplitudes/vector_exchange.cpp
@@ -237,65 +237,61 @@ std::complex<double> jpacPhoto::vector_exchange::covariant_amplitude(std::array<
 // Photon - Axial Vector - Vector vertex
 std::complex<double> jpacPhoto::vector_exchange::top_vertex(int mu, int lam_gam, int lam_vec)
 {
-  std::complex<double> result = 0.;
+    std::complex<double> result = 0.;
 
-  // A-V-V coupling
-  if (IF_SCALAR_X == false)
-  {
-    // Contract with LeviCivita
-    for (int alpha = 0; alpha < 4; alpha++)
+    // A-V-V coupling
+    if (kinematics->JP[0]== 1 && kinematics->JP[1] == 1)
     {
-      for (int beta = 0; beta < 4; beta++)
-      {
-        for (int gamma = 0; gamma < 4; gamma++)
+        // Contract with LeviCivita
+        for (int alpha = 0; alpha < 4; alpha++)
         {
-          std::complex<double> temp;
-          temp = levi_civita(mu, alpha, beta, gamma);
+            for (int beta = 0; beta < 4; beta++)
+            {
+                for (int gamma = 0; gamma < 4; gamma++)
+                {
+                    std::complex<double> temp;
+                    temp = levi_civita(mu, alpha, beta, gamma);
+                    if (std::abs(temp) < 0.001) continue;
+                
+                    temp *= metric[mu];
+                    temp *= kinematics->initial->q(alpha, s, 0.);
+                    temp *= kinematics->eps_gamma->component(beta, lam_gam, s, 0.);
+                    temp *= kinematics->eps_vec->component(gamma, lam_vec, s, theta);
 
-          if (std::abs(temp) < 0.0001) continue;
-        
-          temp *= metric[mu];
-          temp *= kinematics->initial->q(alpha, s, 0.);
-          temp *= kinematics->eps_gamma->component(beta, lam_gam, s, 0.);
-          temp *= kinematics->eps_vec->component(gamma, lam_vec, s, theta);
-
-          result += temp;
+                    result += temp;
+                }
+            }
         }
-      }
     }
-  }
-  // S-V-V coupling
-  else
-  {
-    if (lam_vec != 0)
+
+    // S-V-V coupling
+    else if (kinematics->JP[0]== 0 && kinematics->JP[1] == 1)
     {
-      return 0.;
+        for (int nu = 0; nu < 4; nu++)
+        {
+            std::complex<double> term1, term2;
+
+            // (k . q) eps_gamma^mu
+            term1  = exchange_momenta(nu);
+            term1 *= metric[nu];
+            term1 *= kinematics->initial->q(nu, s, 0.);
+            term1 *= kinematics->eps_gamma->component(mu, lam_gam, s, 0.);
+
+            // (eps_gam . k) q^mu
+            term2  = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
+            term2 *= metric[nu];
+            term2 *= exchange_momenta(nu);
+            term2 *= kinematics->initial->q(mu, s, 0.);
+
+            result += term1 - term2;
+        }
+
+        // Dimensionless coupling requires dividing by the mX
+        result /= kinematics->mX;
     }
 
-    for (int nu = 0; nu < 4; nu++)
-    {
-      std::complex<double> term1, term2;
-
-      // (k . q) eps_gamma^mu
-      term1  = exchange_momenta(nu);
-      term1 *= metric[nu];
-      term1 *= kinematics->initial->q(nu, s, 0.);
-      term1 *= kinematics->eps_gamma->component(mu, lam_gam, s, 0.);
-
-      // (eps_gam . k) q^mu
-      term2  = kinematics->eps_gamma->component(nu, lam_gam, s, 0.);
-      term2 *= metric[nu];
-      term2 *= exchange_momenta(nu);
-      term2 *= kinematics->initial->q(mu, s, 0.);
-
-      result += term1 - term2;
-    }
-    // Dimensionless coupling requires dividing by the mX
-    result /= kinematics->mX;
-  }
-
-  // Multiply by coupling
-  return result * gGam;
+    // Multiply by coupling
+    return result * gGam;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/amplitudes/vector_exchange.cpp
+++ b/src/amplitudes/vector_exchange.cpp
@@ -88,7 +88,7 @@ std::complex<double> jpacPhoto::vector_exchange::top_residue(int lam_gam, int la
     }
     case 1:
     {
-      result = sqrt(xr * t) / kinematics->mVec;
+      result = sqrt(xr * t) / kinematics->mX;
       break;
     }
     default:
@@ -98,7 +98,7 @@ std::complex<double> jpacPhoto::vector_exchange::top_residue(int lam_gam, int la
     }
   }
 
-  std::complex<double> q = (t - kinematics->mVec2) / sqrt(4. * t * xr);
+  std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
   return  xi * double(lam_gam) * result * q * gGam;
 };
 
@@ -193,7 +193,7 @@ std::complex<double> jpacPhoto::vector_exchange::half_angle_factor(int lam, int 
 // Angular momentum barrier factor
 std::complex<double> jpacPhoto::vector_exchange::barrier_factor(int j, int M)
 {
-  std::complex<double> q = (t - kinematics->mVec2) / sqrt(4. * t * xr);
+  std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
   std::complex<double> p = sqrt(xr * t - 4.*mPro2) / 2.;
 
   std::complex<double> result = pow(2. * p * q, double(j - M));
@@ -290,8 +290,8 @@ std::complex<double> jpacPhoto::vector_exchange::top_vertex(int mu, int lam_gam,
 
       result += term1 - term2;
     }
-    // Dimensionless coupling requires dividing by the mVec
-    result /= kinematics->mVec;
+    // Dimensionless coupling requires dividing by the mX
+    result /= kinematics->mX;
   }
 
   // Multiply by coupling

--- a/src/amplitudes/vector_exchange.cpp
+++ b/src/amplitudes/vector_exchange.cpp
@@ -11,59 +11,59 @@
 // Assemble the helicity amplitude by contracting the lorentz indices
 std::complex<double> jpacPhoto::vector_exchange::helicity_amplitude(std::array<int, 4> helicities, double xs, double xt)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  // Update the saved energies and angles
-  s = xs; t = xt;
-  theta = kinematics->theta_s(xs, xt);
-  zt = real(kinematics->z_t(s, theta));
+    // Update the saved energies and angles
+    s = xs; t = xt;
+    theta = kinematics->theta_s(xs, xt);
+    zt = real(kinematics->z_t(s, theta));
 
-  // Output
-  std::complex<double> result;
+    // Output
+    std::complex<double> result;
 
-  if (REGGE == false && FOUR_VEC == true)
-  {
-    result = covariant_amplitude(helicities);
-  }
-  else
-  {
-    // NOTE THIS ONLY WORKS FOR UNPOLARIZED CROSS-SECTIONS
-    // NEED TO WIGNER-ROTATE HELICITES TO S CHANNEL FOR SDMES
-
-    // TODO: ADD CROSSING-MATRICES
-    int lam  = lam_gam - lam_vec;
-    int lamp = (lam_targ - lam_rec) / 2.;
-
-    if (abs(lam) == 2) return 0.; // double flip forbidden!
-
-    // Product of residues  
-    result  = top_residue(lam_gam, lam_vec);
-    result *= bottom_residue(lam_targ, lam_rec);
-
-    // Pole with d function residue if fixed spin
-    if (REGGE == false)
+    if (REGGE == false && FOUR_VEC == true)
     {
-      result *= wigner_d_int_cos(1, lam, lamp, zt);
-      result /= t - mEx2;
+        result = covariant_amplitude(helicities);
     }
-    // or regge propagator if reggeized
     else
     {
-      result *= regge_propagator(1, lam, lamp);
+        // NOTE THIS ONLY WORKS FOR UNPOLARIZED CROSS-SECTIONS
+        // NEED TO WIGNER-ROTATE HELICITES TO S CHANNEL FOR SDMES
+
+        // TODO: ADD CROSSING-MATRICES
+        int lam  = lam_gam - lam_vec;
+        int lamp = (lam_targ - lam_rec) / 2.;
+
+        if (abs(lam) == 2) return 0.; // double flip forbidden!
+
+        // Product of residues  
+        result  = top_residue(lam_gam, lam_vec);
+        result *= bottom_residue(lam_targ, lam_rec);
+
+        // Pole with d function residue if fixed spin
+        if (REGGE == false)
+        {
+            result *= wigner_d_int_cos(1, lam, lamp, zt);
+            result /= t - mEx2;
+        }
+        // or regge propagator if reggeized
+        else
+        {
+            result *= regge_propagator(1, lam, lamp);
+        }
     }
-  }
- 
-  // exponential form factor
-  if (IF_FF == true)
-  {
-    double tprime = t - kinematics->t_man(s, 0.);
-    result *= exp(b * tprime);
-  }
-  
-  return result;
+
+    // exponential form factor
+    if (IF_FF == true)
+    {
+        double tprime = t - kinematics->t_man(s, 0.);
+        result *= exp(b * tprime);
+    }
+
+    return result;
 };
 
 // ---------------------------------------------------------------------------
@@ -76,129 +76,129 @@ std::complex<double> jpacPhoto::vector_exchange::helicity_amplitude(std::array<i
 // Photon - Axial - Vector
 std::complex<double> jpacPhoto::vector_exchange::top_residue(int lam_gam, int lam_vec)
 {
-  int lam = lam_gam - lam_vec;
+    int lam = lam_gam - lam_vec;
 
-  std::complex<double> result;
-  switch (std::abs(lam))
-  {
-    case 0:
+    std::complex<double> result;
+    switch (std::abs(lam))
     {
-      result = 1.;
-      break;
+        case 0:
+        {
+            result = 1.;
+            break;
+        }
+        case 1:
+        {
+            result = sqrt(xr * t) / kinematics->mX;
+            break;
+        }
+        default:
+        {
+            std::cout << "\nvector_exchange: invalid helicity flip lambda = " << lam << "!\n";
+            return 0.;
+        }
     }
-    case 1:
-    {
-      result = sqrt(xr * t) / kinematics->mX;
-      break;
-    }
-    default:
-    {
-      std::cout << "\nvector_exchange: invalid helicity flip lambda = " << lam << "!\n";
-      return 0.;
-    }
-  }
 
-  std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
-  return  xi * double(lam_gam) * result * q * gGam;
+    std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
+    return  xi * double(lam_gam) * result * q * gGam;
 };
 
 // Nucleon - Nucleon - Vector
 std::complex<double> jpacPhoto::vector_exchange::bottom_residue(int lam_targ, int lam_rec)
 {
-  // TODO: Explicit phases in terms of lam_targ and lam_rec instead of difference
-  int lamp = (lam_targ - lam_rec) / 2.;
+    // TODO: Explicit phases in terms of lam_targ and lam_rec instead of difference
+    int lamp = (lam_targ - lam_rec) / 2.;
 
-  std::complex<double> vector, tensor;
-  switch (std::abs(lamp))
-  {
-    case 0:
+    std::complex<double> vector, tensor;
+    switch (std::abs(lamp))
     {
-      vector =  1.;
-      tensor = sqrt(xr * t) / (2. * mPro);
-      break;
+        case 0:
+        {
+            vector =  1.;
+            tensor = sqrt(xr * t) / (2. * mPro);
+            break;
+        }
+        case 1:
+        {
+            vector = sqrt(2.) * sqrt(xr * t) / (2. * mPro);
+            tensor = sqrt(2.);
+            break;
+        }
+        case 2:
+        {
+            return 0.;
+        }
+        default:
+        {
+            std::cout << "\nreggeon_exchange: invalid helicity flip lambda^prime = " << lamp << "!\n";
+            return 0.;
+        }
     }
-    case 1:
-    {
-      vector = sqrt(2.) * sqrt(xr * t) / (2. * mPro);
-      tensor = sqrt(2.);
-      break;
-    }
-    case 2:
-    {
-      return 0.;
-    }
-    default:
-    {
-      std::cout << "\nreggeon_exchange: invalid helicity flip lambda^prime = " << lamp << "!\n";
-      return 0.;
-    }
-  }
 
-  std::complex<double> result;
-  result = gV * vector + gT * tensor * sqrt(xr * t) / (2. * mPro);
-  result *= 2. * mPro;
+    std::complex<double> result;
+    result = gV * vector + gT * tensor * sqrt(xr * t) / (2. * mPro);
+    result *= 2. * mPro;
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
 // Reggeon Propagator
 std::complex<double> jpacPhoto::vector_exchange::regge_propagator(int j, int lam, int lamp)
 {
-  int M = std::max(std::abs(lam), std::abs(lamp));
+    int M = std::max(std::abs(lam), std::abs(lamp));
 
-  if (M > j)
-  {
-    return 0.;
-  }
+    if (M > j)
+    {
+        return 0.;
+    }
 
-  std::complex<double> alpha_t = alpha->eval(t);
+    std::complex<double> alpha_t = alpha->eval(t);
 
-  // the gamma function causes problesm for large t so
-  if (std::abs(alpha_t) > 30.)
-  {
-    return 0.;
-  }
-  else
-  {
-    std::complex<double> result;
-    result  = wigner_leading_coeff(j, lam, lamp);
-    result /= barrier_factor(j, M);
-    result *= half_angle_factor(lam, lamp);
+    // the gamma function causes problesm for large t so
+    if (std::abs(alpha_t) > 30.)
+    {
+        return 0.;
+    }
+    else
+    {
+        std::complex<double> result;
+        result  = wigner_leading_coeff(j, lam, lamp);
+        result /= barrier_factor(j, M);
+        result *= half_angle_factor(lam, lamp);
 
-    result *= - alpha->slope();
-    result *= 0.5 * (double(alpha->signature) + exp(-xi * M_PI * alpha_t));
-    result *= cgamma(1. - alpha_t);
-    result *= pow(s, alpha_t - double(M));
+        result *= - alpha->slope();
+        result *= 0.5 * (double(alpha->signature) + exp(-xi * M_PI * alpha_t));
+        result *= cgamma(1. - alpha_t);
+        result *= pow(s, alpha_t - double(M));
 
-    return result;
-  }
+        return result;
+    }
 };
 
 //------------------------------------------------------------------------------
 // Half angle factors
 std::complex<double> jpacPhoto::vector_exchange::half_angle_factor(int lam, int lamp)
 {
-  std::complex<double> sinhalf = sqrt((xr - zt) / 2.);
-  std::complex<double> coshalf = sqrt((xr + zt) / 2.);
+    std::complex<double> sinhalf = sqrt((xr - zt) / 2.);
+    std::complex<double> coshalf = sqrt((xr + zt) / 2.);
 
-  std::complex<double> result;
-  result  = pow(sinhalf, double(std::abs(lam - lamp)));
-  result *= pow(coshalf, double(std::abs(lam + lamp)));
+    std::complex<double> result;
+    result  = pow(sinhalf, double(std::abs(lam - lamp)));
+    result *= pow(coshalf, double(std::abs(lam + lamp)));
 
-  return result;
+    return result;
 };
 
 //------------------------------------------------------------------------------
 // Angular momentum barrier factor
 std::complex<double> jpacPhoto::vector_exchange::barrier_factor(int j, int M)
 {
-  std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
-  std::complex<double> p = sqrt(xr * t - 4.*mPro2) / 2.;
+    std::complex<double> q = (t - kinematics->mX2) / sqrt(4. * t * xr);
+    std::complex<double> p = sqrt(xr * t - 4.*mPro2) / 2.;
 
-  std::complex<double> result = pow(2. * p * q, double(j - M));
+    std::complex<double> result = pow(2. * p * q, double(j - M));
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
@@ -207,30 +207,30 @@ std::complex<double> jpacPhoto::vector_exchange::barrier_factor(int j, int M)
 
 std::complex<double> jpacPhoto::vector_exchange::covariant_amplitude(std::array<int, 4> helicities)
 {
-  int lam_gam = helicities[0];
-  int lam_targ = helicities[1];
-  int lam_vec = helicities[2];
-  int lam_rec = helicities[3];
+    int lam_gam = helicities[0];
+    int lam_targ = helicities[1];
+    int lam_vec = helicities[2];
+    int lam_rec = helicities[3];
 
-  std::complex<double> result = 0.;
+    std::complex<double> result = 0.;
 
-  // Need to contract the Lorentz indices
-  for (int mu = 0; mu < 4; mu++)
-  {
-    for(int nu = 0; nu < 4; nu++)
+    // Need to contract the Lorentz indices
+    for (int mu = 0; mu < 4; mu++)
     {
-      std::complex<double> temp;
-      temp  = top_vertex(mu, lam_gam, lam_vec);
-      temp *= metric[mu];
-      temp *= vector_propagator(mu, nu);
-      temp *= metric[nu];
-      temp *= bottom_vertex(nu, lam_targ, lam_rec);
+        for(int nu = 0; nu < 4; nu++)
+        {
+            std::complex<double> temp;
+            temp  = top_vertex(mu, lam_gam, lam_vec);
+            temp *= metric[mu];
+            temp *= vector_propagator(mu, nu);
+            temp *= metric[nu];
+            temp *= bottom_vertex(nu, lam_targ, lam_rec);
 
-      result += temp;
+            result += temp;
+        }
     }
-  }
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
@@ -302,43 +302,43 @@ std::complex<double> jpacPhoto::vector_exchange::top_vertex(int mu, int lam_gam,
 // Nucleon - Nucleon - Vector vertex
 std::complex<double> jpacPhoto::vector_exchange::bottom_vertex(int mu, int lam_targ, int lam_rec)
 {
-  // Vector coupling piece
-  std::complex<double> vector = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    // Vector coupling piece
+    std::complex<double> vector = 0.;
+    for (int i = 0; i < 4; i++)
     {
-      std::complex<double> temp;
-      temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
-      temp *= gamma_matrices[mu][i][j];
-      temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
+        for (int j = 0; j < 4; j++)
+        {
+            std::complex<double> temp;
+            temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
+            temp *= gamma_matrices[mu][i][j];
+            temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
 
-      vector += temp;
+            vector += temp;
+        }
     }
-  }
 
-  // Tensor coupling piece
-  std::complex<double> tensor = 0.;
-  for (int i = 0; i < 4; i++)
-  {
-    for (int j = 0; j < 4; j++)
+    // Tensor coupling piece
+    std::complex<double> tensor = 0.;
+    for (int i = 0; i < 4; i++)
     {
-      std::complex<double> sigma_q_ij = 0.;
-      for (int nu = 0; nu < 4; nu++)
-      {
-        sigma_q_ij += sigma(mu, nu, i, j) * metric[nu] * exchange_momenta(nu) / (2. * mPro);
-      }
+        for (int j = 0; j < 4; j++)
+        {
+            std::complex<double> sigma_q_ij = 0.;
+            for (int nu = 0; nu < 4; nu++)
+            {
+            sigma_q_ij += sigma(mu, nu, i, j) * metric[nu] * exchange_momenta(nu) / (2. * mPro);
+            }
 
-      std::complex<double> temp;
-      temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
-      temp *= sigma_q_ij;
-      temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
+            std::complex<double> temp;
+            temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
+            temp *= sigma_q_ij;
+            temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
 
-      tensor += temp;
+            tensor += temp;
+        }
     }
-  }
 
-  return gV * vector - gT * tensor;
+    return gV * vector - gT * tensor;
 };
 
 // ---------------------------------------------------------------------------
@@ -346,27 +346,27 @@ std::complex<double> jpacPhoto::vector_exchange::bottom_vertex(int mu, int lam_t
 // Simply the difference of the photon and axial 4-momenta
 std::complex<double> jpacPhoto::vector_exchange::exchange_momenta(int mu)
 {
-  std::complex<double> qGamma_mu, qA_mu;
-  qGamma_mu = kinematics->initial->q(mu, s, 0.);
-  qA_mu = kinematics->final->q(mu, s, theta);
+    std::complex<double> qGamma_mu, qA_mu;
+    qGamma_mu = kinematics->initial->q(mu, s, 0.);
+    qA_mu = kinematics->final->q(mu, s, theta);
 
-  return (qGamma_mu - qA_mu);
+    return (qGamma_mu - qA_mu);
 };
 
 // ---------------------------------------------------------------------------
 // Propagator of a massive spin-one particle
 std::complex<double> jpacPhoto::vector_exchange::vector_propagator(int mu, int nu)
 {
-  // q_mu q_nu / mEx2 - g_mu nu
-  std::complex<double> result;
-  result = exchange_momenta(mu) * exchange_momenta(nu) / mEx2;
+    // q_mu q_nu / mEx2 - g_mu nu
+    std::complex<double> result;
+    result = exchange_momenta(mu) * exchange_momenta(nu) / mEx2;
 
-  if (mu == nu)
-  {
-    result -= metric[mu];
-  }
+    if (mu == nu)
+    {
+        result -= metric[mu];
+    }
 
-  result /= t - mEx2;
+    result /= t - mEx2;
 
-  return result;
+    return result;
 };

--- a/src/amplitudes/vector_exchange.cpp
+++ b/src/amplitudes/vector_exchange.cpp
@@ -24,7 +24,8 @@ std::complex<double> jpacPhoto::vector_exchange::helicity_amplitude(std::array<i
     // Output
     std::complex<double> result;
 
-    if (REGGE == false && FOUR_VEC == true)
+    // if psuedo scalar or scalar production do covariant
+    if (!(kinematics->JP[0] == 1 && kinematics->JP[1] == 1) || FOUR_VEC == true)
     {
         result = covariant_amplitude(helicities);
     }
@@ -325,8 +326,7 @@ std::complex<double> jpacPhoto::vector_exchange::top_vertex(int mu, int lam_gam,
                 
                     temp *= metric[mu];
                     temp *= field_tensor(alpha, beta, lam_gam);
-                    temp *= (exchange_momenta(gamma) - kinematics->final->q(gamma, s, M_PI));
-
+                    temp *= kinematics->final->q(gamma, s, M_PI) - exchange_momenta(gamma);
                     result += temp;
                 }
             }
@@ -358,22 +358,25 @@ std::complex<double> jpacPhoto::vector_exchange::bottom_vertex(int mu, int lam_t
 
     // Tensor coupling piece
     std::complex<double> tensor = 0.;
-    for (int i = 0; i < 4; i++)
+    if (abs(gT) > 0.001)
     {
-        for (int j = 0; j < 4; j++)
+        for (int i = 0; i < 4; i++)
         {
-            std::complex<double> sigma_q_ij = 0.;
-            for (int nu = 0; nu < 4; nu++)
+            for (int j = 0; j < 4; j++)
             {
-            sigma_q_ij += sigma(mu, nu, i, j) * metric[nu] * exchange_momenta(nu) / (2. * mPro);
+                std::complex<double> sigma_q_ij = 0.;
+                for (int nu = 0; nu < 4; nu++)
+                {
+                sigma_q_ij += sigma(mu, nu, i, j) * metric[nu] * exchange_momenta(nu) / (2. * mPro);
+                }
+
+                std::complex<double> temp;
+                temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
+                temp *= sigma_q_ij;
+                temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
+
+                tensor += temp;
             }
-
-            std::complex<double> temp;
-            temp = kinematics->recoil->adjoint_component(i, lam_rec, s, theta + M_PI); // theta_rec = theta + pi
-            temp *= sigma_q_ij;
-            temp *= kinematics->target->component(j, lam_targ, s, M_PI); // theta_targ = pi
-
-            tensor += temp;
         }
     }
 

--- a/src/dirac_spinor.cpp
+++ b/src/dirac_spinor.cpp
@@ -11,23 +11,23 @@
 // Energy part
 std::complex<double> jpacPhoto::dirac_spinor::omega(int sign, double s)
 {
-  if (ANTI_PARTICLE)
-  {
-    sign *= -1;
-  }
+    if (ANTI_PARTICLE)
+    {
+        sign *= -1;
+    }
 
-  std::complex<double> E = state->energy_B(s);
-  return sqrt(xr * E + double(sign) * state->get_mB());
+    std::complex<double> E = state->energy_B(s);
+    return sqrt(xr * E + double(sign) * state->get_mB());
 }
 
 // ---------------------------------------------------------------------------
 // Angular half angle factors
 double jpacPhoto::dirac_spinor::half_angle(int lam, double theta)
 {
-  double result;
-  (lam == 1) ? (result = cos(theta / 2.)) : (result = sin(theta / 2.));
+    double result;
+    (lam == 1) ? (result = cos(theta / 2.)) : (result = sin(theta / 2.));
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
@@ -35,29 +35,28 @@ double jpacPhoto::dirac_spinor::half_angle(int lam, double theta)
 // Assumed to be particle 2 but moving in the +z direction
 std::complex<double> jpacPhoto::dirac_spinor::component(int i, int lambda, double s, double theta)
 {
-  if (abs(lambda) != 1)
-  {
-    std::cout << "\ndirac_spinor: Invalid helicity projection passed as argument!\n";
-    return 0.;
-  }
+    if (abs(lambda) != 1)
+    {
+        std::cout << "\ndirac_spinor: Invalid helicity projection passed as argument!\n";
+        return 0.;
+    }
 
-  // theta convention
-  switch (i)
-  {
-    case 0: return                  omega(+1, s) * half_angle( lambda, theta);
-    case 1: return double(lambda) * omega(+1, s) * half_angle(-lambda, theta);
-    case 2: return double(lambda) * omega(-1, s) * half_angle( lambda, theta);
-    case 3: return                  omega(-1, s) * half_angle(-lambda, theta);
-    default : std::cout << "dirac_spinor: Invalid component index " << i << " passed as argument!\n";
-              return 0.;
-  }
-
+    // theta convention
+    switch (i)
+    {
+        case 0: return                  omega(+1, s) * half_angle( lambda, theta);
+        case 1: return double(lambda) * omega(+1, s) * half_angle(-lambda, theta);
+        case 2: return double(lambda) * omega(-1, s) * half_angle( lambda, theta);
+        case 3: return                  omega(-1, s) * half_angle(-lambda, theta);
+        default : std::cout << "dirac_spinor: Invalid component index " << i << " passed as argument!\n";
+                  return 0.;
+    }
 };
 
 std::complex<double> jpacPhoto::dirac_spinor::adjoint_component(int i, int lambda, double s, double theta)
 {
-  double phase;
-  (i == 2 || i == 3) ? (phase = -1.) : (phase = 1.);
+    double phase;
+    (i == 2 || i == 3) ? (phase = -1.) : (phase = 1.);
 
-  return phase * component(i, lambda, s, theta);
+    return phase * component(i, lambda, s, theta);
 };

--- a/src/gamma_technology.cpp
+++ b/src/gamma_technology.cpp
@@ -11,27 +11,27 @@
 // Rank two gamma tensor
 std::complex<double> jpacPhoto::sigma(int mu, int nu, int i, int j)
 {
-  std::complex<double> result = 0.;
-  for (int k = 0; k < 4; k++)
-  {
-    result += gamma_matrices[mu][i][k] * gamma_matrices[nu][k][j];
-    result -= gamma_matrices[nu][i][k] * gamma_matrices[mu][k][j];
-  }
+    std::complex<double> result = 0.;
+    for (int k = 0; k < 4; k++)
+    {
+        result += gamma_matrices[mu][i][k] * gamma_matrices[nu][k][j];
+        result -= gamma_matrices[nu][i][k] * gamma_matrices[mu][k][j];
+    }
 
-  result *= xr / 2.;
+    result *= xr / 2.;
 
-  return result;
+    return result;
 };
 
 // ---------------------------------------------------------------------------
 // Four dimensional Levi-Civita symbol
 double jpacPhoto::levi_civita(int a, int b, int c, int d)
 {
-  int result = (d - c) * (d - b) * (d - a) * (c - b) * (c - a) * (b - a);
+    int result = (d - c) * (d - b) * (d - a) * (c - b) * (c - a) * (b - a);
 
-  if (result == 0) return 0.;
+    if (result == 0) return 0.;
 
-  result /= abs(d - c) * abs(d - b) * abs(d - a) * abs(c - b) * abs(c - a) * abs(b - a);
-    
-  return result;
+    result /= abs(d - c) * abs(d - b) * abs(d - a) * abs(c - b) * abs(c - a) * abs(b - a);
+
+    return result;
 };

--- a/src/polarization_vector.cpp
+++ b/src/polarization_vector.cpp
@@ -15,43 +15,34 @@
 // vectors are always particle 1
 std::complex<double> jpacPhoto::polarization_vector::component(int i, int lambda, double s, double theta)
 {
-  if (abs(lambda) == 1)
-  {
-    switch (i)
+    // Check for massless photon
+    if (lambda == 0 && abs(state->get_mV()) < 0.01){return 0.;}
+
+    int id = 10 * abs(lambda) + i;
+    switch (id)
     {
-      case 0: return 0.;
-      case 1: return - double(lambda) * cos(theta) / sqrt(2.);
-      case 2: return - xi / sqrt(2.);
-      case 3: return double(lambda) * sin(theta) / sqrt(2.);
-    }
-  }
-  else if (lambda == 0)
-  {
-    if (abs(state->get_mV()) < 0.01) // if massless this is zero
-    {
-      return 0.;
-    }
-    else
-    {
-      switch (i)
-      {
+        // Longitudinal
         case 0: return state->momentum(s) / state->get_mV();
         case 1: return state->energy_V(s) * sin(theta) / state->get_mV();
         case 2: return 0.;
         case 3: return state->energy_V(s) * cos(theta) / state->get_mV();
-      }
-    }
-  }
-  else
-  {
-    std::cout << "polarization_vector: Invalid helicity! Quitting... \n";
-    return 0.;
-  }
 
-  return 0.;
+        // Transverse
+        case 10: return 0.;
+        case 11: return - double(lambda) * cos(theta) / sqrt(2.);
+        case 12: return - xi / sqrt(2.);
+        case 13: return double(lambda) * sin(theta) / sqrt(2.);
+
+        default: 
+        {
+            std::cout << "polarization_vector: Invalid helicity! Quitting... \n";
+            return 0.; 
+        }
+    };
+
 };
 
 std::complex<double> jpacPhoto::polarization_vector::conjugate_component(int i, int lambda, double s, double theta)
 {
-  return conj(component(i, lambda, s, theta));
+    return conj(component(i, lambda, s, theta));
 };

--- a/src/two_body_state.cpp
+++ b/src/two_body_state.cpp
@@ -13,34 +13,34 @@
 // The four momentum of the vector particle
 std::complex<double> jpacPhoto::two_body_state::q(int mu, double s, double theta)
 {
-  switch (mu)
-  {
-    case 0: return energy_V(s);
-    case 1: return momentum(s) * sin(theta);
-    case 2: return 0.;
-    case 3: return momentum(s) * cos(theta);
-    default: 
+    switch (mu)
     {
-      std::cout << "two_body_state: Invalid four vector component! \n";
-      return 0.;
+        case 0: return energy_V(s);
+        case 1: return momentum(s) * sin(theta);
+        case 2: return 0.;
+        case 3: return momentum(s) * cos(theta);
+        default: 
+        {
+            std::cout << "two_body_state: Invalid four vector component! \n";
+            return 0.;
+        }
     }
-  }
 };
 
 // ---------------------------------------------------------------------------
 // The four momenta of the baryon
 std::complex<double> jpacPhoto::two_body_state::p(int mu, double s, double theta)
 {
-  switch (mu)
-  {
-    case 0: return energy_B(s);
-    case 1: return - momentum(s) * sin(theta);
-    case 2: return 0.;
-    case 3: return - momentum(s) * cos(theta);
-    default: 
+    switch (mu)
     {
-      std::cout << "two_body_state: Invalid four vector component! \n";
-      return 0.;
+        case 0: return energy_B(s);
+        case 1: return - momentum(s) * sin(theta);
+        case 2: return 0.;
+        case 3: return - momentum(s) * cos(theta);
+        default: 
+        {
+            std::cout << "two_body_state: Invalid four vector component! \n";
+            return 0.;
+        }
     }
-  }
 };

--- a/src/wigner_d.cpp
+++ b/src/wigner_d.cpp
@@ -10,394 +10,273 @@
 // --------------------------------------------------------------------------
 double jpacPhoto::wigner_leading_coeff(int j, int lam1, int lam2)
 {
-  int M = std::max(std::abs(lam1), std::abs(lam2));
-  int N = std::min(std::abs(lam1), std::abs(lam2));
+    int M = std::max(std::abs(lam1), std::abs(lam2));
+    int N = std::min(std::abs(lam1), std::abs(lam2));
 
-  int lambda = std::abs(lam1 - lam2) + lam1 - lam2;
+    int lambda = std::abs(lam1 - lam2) + lam1 - lam2;
 
-  double result = (double) factorial(2*j);
-  result /= sqrt( (double) factorial(j-M));
-  result /= sqrt( (double) factorial(j+M));
-  result /= sqrt( (double) factorial(j-N));
-  result /= sqrt( (double) factorial(j+N));
-  result /= pow(2.,  double(j-M));
-  result *= pow(-1., double(lambda)/2.);
+    double result = (double) factorial(2*j);
+    result /= sqrt( (double) factorial(j-M));
+    result /= sqrt( (double) factorial(j+M));
+    result /= sqrt( (double) factorial(j-N));
+    result /= sqrt( (double) factorial(j+N));
+    result /= pow(2.,  double(j-M));
+    result *= pow(-1., double(lambda)/2.);
 
-  return result;
+    return result;
 };
 
-// ---------------------------------------------------------------------------
-double jpacPhoto::wigner_error(int j, int lam1, int lam2, bool half)
-{
-  // if (half == true)
-  // {
-  //   std::cout << "\n";
-  //   std::cout << "wigner_d: Argument combination with j = " << j << "/2";
-  //   std::cout << ", lam1 = " << lam1 << "/2";
-  //   std::cout << ", lam2 = " << lam2 << "/2";
-  //   std::cout << " does not exist. Quitting... \n";
-  // }
-  // else
-  // {
-  //   std::cout << "\n";
-  //   std::cout << "wigner_d: Argument combination with j = " << j;
-  //   std::cout << ", lam1 = " << lam1;
-  //   std::cout << ", lam2 = " << lam2;
-  //   std::cout << " does not exist. Quitting... \n";
-  // }
-  //
-  // exit(0);
-
-  return 0.;
-}
 // ---------------------------------------------------------------------------
 // USING WIKIPEDIA SIGN CONVENTION
 // theta is in radians
 // lam1 = 2 * lambda and lam2 = 2 * lambda^prime are integers
 double jpacPhoto::wigner_d_half(int j, int lam1, int lam2, double theta)
 {
-  double phase = 1.;
+    double phase = 1.;
 
-  // If first lam argument is smaller, switch them
-  if (abs(lam1) < abs(lam2))
-  {
-    int temp = lam1;
-    lam1 = lam2;
-    lam2 = temp;
-
-    phase *= pow(-1., double(lam1 - lam2) / 2.);
-  };
-
-  // If first lam is negative, smitch them
-  if (lam1 < 0)
-  {
-    lam1 *= -1;
-    lam2 *= -1;
-
-    phase *= pow(-1., double(lam1 - lam2) / 2.);
-  }
-
-  double result = 0.;
-  switch (j)
-  {
-    // -------------------------------------------------------------------------
-    // j = 1/2
-    // -------------------------------------------------------------------------
-    case 1:
+    // If first lam argument is smaller, switch them
+    if (abs(lam1) < abs(lam2))
     {
-      if (lam1 == 1)
-      {
-        if (lam2 == 1)
-        {
-          result = cos(theta / 2.);
-          break;
-        }
-        else
-        {
-          result = -sin(theta / 2.);
-          break;
-        }
-      }
-      else
-      {
-        wigner_error(j, lam1, lam2, true);
-      }
-      break;
+        int temp = lam1;
+        lam1 = lam2;
+        lam2 = temp;
+
+        phase *= pow(-1., double(lam1 - lam2) / 2.);
+    };
+
+    // If first lam is negative, switch them
+    if (lam1 < 0)
+    {
+        lam1 *= -1;
+        lam2 *= -1;
+
+        phase *= pow(-1., double(lam1 - lam2) / 2.);
     }
 
-    // -------------------------------------------------------------------------
-    // j = 3/2
-    // -------------------------------------------------------------------------
-    case 3:
+    double result = 0.;
+
+    int id = ((lam2 > 0) - (lam2 < 0)) * (j * 100 + lam1 * 10 + abs(lam2)); // negative sign refers to negative lam2
+    switch (id)
     {
-      // Lambda = 3/2
-      if (lam1 == 3)
-      {
-        switch (lam2)
+        // spin 1/2 
+        case  111: 
         {
-          case 3:
-          {
-             result = cos(theta / 2.) / 2.;
-             result *= (1. + cos(theta));
-             break;
-          }
-          case 1:
-          {
+            result =  cos(theta / 2.); 
+            break;
+        };
+        case -111: 
+        {
+            result = -sin(theta / 2.); 
+            break;
+        };
+
+        // spin 3/2
+        case  333:       
+        {
+            result = cos(theta / 2.) / 2.;
+            result *= (1. + cos(theta));
+            break;
+        }
+        case  331:
+        {
             result = - sqrt(3.) / 2.;
             result *= sin(theta / 2.);
             result *= 1. + cos(theta);
             break;
-          }
-          case -1:
-          {
+        }
+        case -331:
+        {
             result = sqrt(3.) / 2.;
             result *= cos(theta / 2.);
             result *= 1. - cos(theta);
-           break;
-          }
-          case -3:
-          {
+            break;
+        }
+        case -333:
+        {
             result = - sin(theta / 2.) / 2.;
             result *= 1. - cos(theta);
             break;
-          }
-          default: wigner_error(j, lam1, lam2, true);
         }
-      }
-
-      // Lambda = 1/2
-      else if (lam1 == 1)
-      {
-        switch (lam2)
+        case  311:
         {
-          case 1:
-          {
             result = 1. / 2.;
             result *= 3. * cos(theta) - 1.;
             result *= cos(theta / 2.);
             break;
-          }
-          case -1:
-          {
+        }
+        case -311:
+        {
             result = -1. / 2.;
             result *= 3. * cos(theta) + 1.;
             result *= sin(theta / 2.);
             break;
-          }
-          default: wigner_error(j, lam1, lam2, true);
         }
-      }
 
-      // Error
-      else
-      {
-        wigner_error(j, lam1, lam2, true);
-      }
-      break;
-    }
+        // Spin- 5/2
+        case  533:
+        {
+            result = -1. / 4.;
+            result *= cos(theta / 2.);
+            result *= (1. + cos(theta)) * (3. - 5. * cos(theta));
+            break;
+        }
+        case  531:
+        {
+            result = sqrt(2.) / 4.;
+            result *= sin(theta / 2.);
+            result *= (1. + cos(theta)) * (1. - 5. * cos(theta));
+            break;
+        }
+        case -531:
+        {
+            result =  sqrt(2.) / 4.;
+            result *= cos(theta / 2.);
+            result *= (1. - cos(theta)) * (1. + 5. * cos(theta));
+            break;
+        }
+        case -533:
+        {
+            result = -1. / 4.;
+            result *= sin(theta / 2.);
+            result *= (1. - cos(theta)) * (3. + 5. * cos(theta));
+            break;
+        }
+        case  511:
+        {
+            result = -1. / 2.;
+            result *= cos(theta / 2.);
+            result *= (1. + 2. * cos(theta) - 5. * cos(theta)*cos(theta));
+            break;
+        }
+        case -511:
+        {
+            result = 1. / 2.;
+            result *= sin(theta / 2.);
+            result *= (1. - 2. * cos(theta) - 5. * cos(theta)*cos(theta));
+            break;
+        }
 
-    // -------------------------------------------------------------------------
-    // j = 5/2
-    // -------------------------------------------------------------------------
-    case 5:
-    {
-      switch (lam1)
-      {
-        // lambda = 5/2 not yet implemented
-        case 5:
-        {
-          wigner_error(j, lam1, lam2, true);
-        }
-        // lam1 == 3
-        case 3:
-        {
-          switch (lam2)
-          {
-            case 3:
-            {
-              result = -1. / 4.;
-              result *= cos(theta / 2.);
-              result *= (1. + cos(theta)) * (3. - 5. * cos(theta));
-              break;
-            }
-            case 1:
-            {
-              result = sqrt(2.) / 4.;
-              result *= sin(theta / 2.);
-              result *= (1. + cos(theta)) * (1. - 5. * cos(theta));
-              break;
-            }
-            case -1:
-            {
-              result =  sqrt(2.) / 4.;
-              result *= cos(theta / 2.);
-              result *= (1. - cos(theta)) * (1. + 5. * cos(theta));
-              break;
-            }
-            case -3:
-            {
-              result = -1. / 4.;
-              result *= sin(theta / 2.);
-              result *= (1. - cos(theta)) * (3. + 5. * cos(theta));
-              break;
-            }
-            default: wigner_error(j, lam1, lam2, true);
-          }
-          break;
-        }
-        // lam1 == 1
-        case 1:
-        {
-          switch (lam2)
-          {
-            case 1:
-            {
-              result = -1. / 2.;
-              result *= cos(theta / 2.);
-              result *= (1. + 2. * cos(theta) - 5. * cos(theta)*cos(theta));
-              break;
-            }
-            case -1:
-            {
-              result = 1. / 2.;
-              result *= sin(theta / 2.);
-              result *= (1. - 2. * cos(theta) - 5. * cos(theta)*cos(theta));
-              break;
-            }
-            default: wigner_error(j, lam1, lam2, true);
-          }
-          break;
-        }
-        default: wigner_error(j, lam1, lam2, true);
-      }
-      break;
-    }
-    // Error
-    default: wigner_error(j, lam1, lam2, true);
-  }
+        default: return 0.;
+    };
 
-  return phase * result;
+    return phase * result;
 };
 
 // ---------------------------------------------------------------------------
 double jpacPhoto::wigner_d_int(int j, int lam1, int lam2, double theta)
 {
 
-  double phase = 1.;
-  // If first lam argument is smaller, switch them
-  if (abs(lam1) < abs(lam2))
-  {
-    int temp = lam1;
-    lam1 = lam2;
-    lam2 = temp;
-
-    phase *= pow(-1., double(lam1 - lam2));
-  };
-
-  // If first lam is negative, smitch them
-  if (lam1 < 0)
-  {
-    lam1 *= -1;
-    lam2 *= -1;
-
-    phase *= pow(-1., double(lam1 - lam2));
-  }
-
-  double result = 0.;
-  switch (j)
-  {
-    // spin - 1
-    case 1:
+    double phase = 1.;
+    // If first lam argument is smaller, switch them
+    if (abs(lam1) < abs(lam2))
     {
-      if (lam1 == 1)
-      {
-        switch (lam2)
+        int temp = lam1;
+        lam1 = lam2;
+        lam2 = temp;
+
+        phase *= pow(-1., double(lam1 - lam2));
+    };
+
+    // If first lam is negative, smitch them
+    if (lam1 < 0)
+    {
+        lam1 *= -1;
+        lam2 *= -1;
+
+        phase *= pow(-1., double(lam1 - lam2));
+    }
+
+    // Output
+    double result = 0.;
+
+    int id = ((lam2 >= 0) - (lam2 < 0)) * (j * 100 + lam1 * 10 + abs(lam2)); // negative sign refers to negative lam2
+    switch (id)
+    {   
+        // Spin 1
+        case  111:
         {
-          case 1:
-          {
             result = (1. + cos(theta)) / 2.;
             break;
-          }
-          case 0:
-          {
+        }
+        case  110:
+        {
             result = - sin(theta) / sqrt(2.);
             break;
-          }
-          case -1:
-          {
+        }
+        case -111:
+        {
             result = (1. - cos(theta)) / 2.;
             break;
-          }
-          default: wigner_error(j, lam1, lam2, false);
         }
-      }
-      else if (lam1 == 0)
-      {
-        result = cos(theta);
-      }
-      else
-      {
-        wigner_error(j, lam1, lam2, false);
-      }
-      break;
-    }
-  // Error
-  default: wigner_error(j, lam1, lam2, false);
-}
+        case  100:
+        {
+            result = cos(theta);
+            break;
+        }
 
-return phase * result;
+        default: return 0.;
+    }
+
+    return phase * result;
 };
 
 // ---------------------------------------------------------------------------
 std::complex<double> jpacPhoto::wigner_d_int_cos(int j, int lam1, int lam2, double cosine)
 {
-  // Careful because this loses the +- phase of the sintheta. 
-  std::complex<double> sine = sqrt(xr - cosine * cosine);
+    // Careful because this loses the +- phase of the sintheta. 
+    std::complex<double> sine = sqrt(xr - cosine * cosine);
 
-  std::complex<double> sinhalf =  sqrt((xr - cosine) / 2.);
-  std::complex<double> coshalf =  sqrt((xr + cosine) / 2.);
+    std::complex<double> sinhalf =  sqrt((xr - cosine) / 2.);
+    std::complex<double> coshalf =  sqrt((xr + cosine) / 2.);
 
-  double phase = 1.;
-  // If first lam argument is smaller, switch them
-  if (abs(lam1) < abs(lam2))
-  {
-    int temp = lam1;
-    lam1 = lam2;
-    lam2 = temp;
-
-    phase *= pow(-1., double(lam1 - lam2));
-  };
-
-  // If first lam is negative, smitch them
-  if (lam1 < 0)
-  {
-    lam1 *= -1;
-    lam2 *= -1;
-
-    phase *= pow(-1., double(lam1 - lam2));
-  }
-
-  std::complex<double> result = 0.;
-  switch (j)
-  {
-    // spin - 1
-    case 1:
+    double phase = 1.;
+    // If first lam argument is smaller, switch them
+    if (abs(lam1) < abs(lam2))
     {
-      if (lam1 == 1)
-      {
-        switch (lam2)
+        int temp = lam1;
+        lam1 = lam2;
+        lam2 = temp;
+
+        phase *= pow(-1., double(lam1 - lam2));
+    };
+
+    // If first lam is negative, smitch them
+    if (lam1 < 0)
+    {
+        lam1 *= -1;
+        lam2 *= -1;
+
+        phase *= pow(-1., double(lam1 - lam2));
+    }
+
+    std::complex<double> result = 0.;
+    int id = ((lam2 >= 0) - (lam2 < 0)) * (j * 100 + lam1 * 10 + abs(lam2)); // negative sign refers to negative lam2
+    switch (id)
+    {   
+        // Spin 1
+        case  111:
         {
-          case 1:
-          {
             result = (1. + cosine) / 2.;
             break;
-          }
-          case 0:
-          {
+        }
+        case  110:
+        {
             result = - sine / sqrt(2.);
             break;
-          }
-          case -1:
-          {
+        }
+        case -111:
+        {
             result = (1. - cosine) / 2.;
             break;
-          }
-          default: wigner_error(j, lam1, lam2, false);
         }
-      }
-      else if (lam1 == 0)
-      {
-        result = cosine;
-      }
-      else
-      {
-        wigner_error(j, lam1, lam2, false);
-      }
-      break;
-    }
-  // Error
-  default: wigner_error(j, lam1, lam2, false);
-}
+        case  100:
+        {
+            result = cosine;
+            break;
+        }
 
-return phase * result;
+        default: return 0.;
+    }
+
+    return phase * result;
 };


### PR DESCRIPTION
** Changes to reaction_kinematics class:** 
1.  Spin, J, and parity of the produced meson now specifiable through set_JP(double, double)
2.  All four particle masses allowed to be specified for example: new reaction_kinematics(mX, mTarget, mRecoil, mBeam)

** Changes to amplitudes ***
1.  Each amplitude must now specify which JP combinations are implemented with virtual class allowed_JP();
2. Added helicity combinations for spin 0 and spin 2.
3. vector_exchange now allows to choose between no, exponential, or monopole formfactor.
4. vector_exchange for pseudo-scalar production added.
5. pomeron_exchange now may now choose between three models: JPAC2019, JPAC2016, and Wang et al.

** Other **
1. added photoPlotter class, an more succinct interface with jpacStyle which takes in directly a vector of amplitudes.
2. Cleaned up tabbing for more consistent style in all files
